### PR TITLE
FIO-6552: Fixes page not reloaded after second time calling samlInit method

### DIFF
--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -2190,7 +2190,7 @@ export class Formio {
       if (window.location.hash) {
         uri += window.location.hash;
       }
-      window.history.replaceState({}, document.title, uri);
+      window.location.replace(uri);
       return retVal;
     }
 


### PR DESCRIPTION
**Dependencies**: [formio-server:1238](https://github.com/formio/formio-server/pull/1238)

**Explanation**:
When doing SAML login flow, [our doc](https://help.form.io/developers/auth/saml#login-form-configuration) suggests form configuration with `window.location.replace('/')` call in order to reload the page after sucessful SAML login.
Howewer, there is a `window.history.replaceState(...)` call in `samlInit` method, which (I suppose) should do this reload.
But for some reason `history.replaceState` method is not triggering the page reload in that case, despite changing the URL in browser UI.
That's why I've changed this line to use `location.replace` method instead, as it triggers the page reload and makes both SAML login with button and Auto login flows work well without extra page reload conditions from the form configuration.