### PR TITLE
FIO-6964: Fixes server crashing if useSessionToken option passed

### DIFF
--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -1688,6 +1688,10 @@ export class Formio {
   }
 
   static useSessionToken(options: string | { namespace: string}) {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+
     let namespace = options
     if (typeof options === 'object') {
         options = options.namespace


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6964

## Description

**What changed?**

Previously, there was no check that `useSessionToken` method is executed on server side and as the function relates to `localStorage` and `sessionStorage` and they're not available in server environment, the app crashed.

## Dependencies

None

## How has this PR been tested?

Manually

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
