### PR TITLE
revert accidental deletion of templateSettings

### DIFF
--- a/src/utils/Evaluator.ts
+++ b/src/utils/Evaluator.ts
@@ -2,6 +2,11 @@ import * as _ from '@formio/lodash';
 
 // BaseEvaluator is for extending.
 export class BaseEvaluator {
+    static templateSettings = {
+        interpolate: /{{([\s\S]+?)}}/g,
+        evaluate: /\{%([\s\S]+?)%\}/g,
+        escape: /\{\{\{([\s\S]+?)\}\}\}/g
+    };
     public static noeval: boolean = false;
     public static evaluator(func: any, ...params: any) {
         if (Evaluator.noeval) {


### PR DESCRIPTION
Somehow the `templateSettings` private parameter got removed in #21 . This PR restores the templateSettings variable, although not as `private` because TS refused to compile it as such