### PR TITLE
FIO-7462: fix failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "./validation": "./lib/process/validation/index.js"
   },
   "scripts": {
-    "test": "mocha -r ts-node/register -r tsconfig-paths/register -r mock-local-storage -r jsdom-global/register -b -t 0 'src/**/__tests__/*.test.ts'",
+    "test": "TEST=1 mocha -r ts-node/register -r tsconfig-paths/register -r mock-local-storage -r jsdom-global/register -b -t 0 'src/**/__tests__/*.test.ts'",
     "lib": "tsc --project tsconfig.json && tsc-alias -p tsconfig.json",
     "replace": "node -r tsconfig-paths/register -r ts-node/register ./lib/base/array/ArrayComponent.js",
     "test:debug": "mocha -r ts-node/register -r tsconfig-paths/register -r mock-local-storage -r jsdom-global/register --debug-brk --inspect '**/*.spec.ts'",

--- a/src/base/component/__tests__/Component.test.ts
+++ b/src/base/component/__tests__/Component.test.ts
@@ -1,13 +1,8 @@
 import { Component as ComponentBase } from '../Component';
-import { validate } from 'validation';
-var jsdom = require('mocha-jsdom');
 import { assert } from 'chai';
 const Component = ComponentBase()();
 
 describe('Component', () => {
-    jsdom({
-        url: "http://localhost"
-    });
     it('Should create a new Component component', () => {
         // Default to an empty object.
         const comp = new Component({

--- a/src/components/__tests__/htmlcontainer.test.ts
+++ b/src/components/__tests__/htmlcontainer.test.ts
@@ -1,12 +1,8 @@
-var jsdom = require('mocha-jsdom');
 import { assert } from 'chai';
 import { HTMLContainerComponent } from '../test';
 import { comp1, comp2 } from './fixtures';
 
 describe('HTMLContainerComponent', () => {
-    jsdom({
-        url: "http://localhost"
-    });
     it ('Should create an HTMLContainerComponent', () => {
         const comp = new HTMLContainerComponent(comp1);
         assert.equal(comp.render(), '<div ref="htmlcontainer" one="two" three="four" class="testing">' +

--- a/src/components/input/__tests__/input.test.ts
+++ b/src/components/input/__tests__/input.test.ts
@@ -1,12 +1,8 @@
-var jsdom = require('mocha-jsdom');
 import { assert } from 'chai';
 import { InputComponent, HTMLContainerComponent } from '../../test';
 import { comp1, comp2 } from './fixtures';
 
 describe('Input Component', () => {
-    jsdom({
-        url: "http://localhost"
-    });
     it('Should create a new input component', () => {
         const comp = new InputComponent(comp1);
         assert.equal(comp.render(), `<input ref="input" type="text" id="input-firstname" name="input-firstname" one="two" three="four"></input>`);

--- a/src/process/validation/rules/__tests__/validateRemoteSelectValue.test.ts
+++ b/src/process/validation/rules/__tests__/validateRemoteSelectValue.test.ts
@@ -89,7 +89,7 @@ it('Validating a select component with the remote validation parameter will retu
             value: 2,
         },
     };
-    fetchMock.mock(component.data.url, JSON.stringify({}), {
+    fetchMock.mock(component.data.url, JSON.stringify([]), {
         query: { [component.searchField!]: data.component.value },
     });
 

--- a/src/process/validation/rules/validateRemoteSelectValue.ts
+++ b/src/process/validation/rules/validateRemoteSelectValue.ts
@@ -41,7 +41,7 @@ export const generateUrl = (baseUrl: URL, component: SelectComponent, value: any
 export const validateRemoteSelectValue: RuleFn = async (context) => {
     const { component, value, data, config } = context;
     // Only run this validation if server-side
-    if (typeof window !== 'undefined') {
+    if (!process?.env?.TEST && typeof window !== 'undefined') {
         return null;
     }
     try {

--- a/src/proxy/__tests__/Instance.test.ts
+++ b/src/proxy/__tests__/Instance.test.ts
@@ -22,6 +22,6 @@ describe('InstanceProxy', () => {
         assert.deepEqual(proxy.data, { firstName: 'Joe' }, 'Should have access to the public data variable');
         assert.equal(proxy.getValue(), 'Joe', 'Should have access to the public getValue function');
         assert(proxy.root instanceof FormProxy, 'It should return a FormProxy for the root variable.');
-        assert.equal(typeof proxy.options.badFunction, 'string', 'It should not be able to execute a function.');
+        assert.equal(typeof proxy.options.badFunction, 'undefined', 'It should not be able to execute a function.');
     });
 });

--- a/src/sdk/__tests__/Formio.test.ts
+++ b/src/sdk/__tests__/Formio.test.ts
@@ -1,4 +1,3 @@
-var jsdom = require('mocha-jsdom');
 import { Formio } from '../Formio';
 import { fastCloneDeep } from '@formio/lodash';
 import _each from 'lodash/each';
@@ -52,9 +51,6 @@ const runTests = function(fn: any, options?: any) {
 };
 
 describe('Formio.js Tests', () => {
-  jsdom({
-    url: "http://localhost"
-  });
   describe('Formio Constructor Tests', () => {
     runTests((tests: any) => {
       tests[`http://form.io/project/${  projectId  }/form/${  formId}`] = {


### PR DESCRIPTION
Core tests were failing because of (a) our JSDOM implementation and (b) some minor issues.

(a) JSDOM was instantiating a global `window` object, so any validation rules that are designed to only work on the server were returning `null` and not validating. Adding a simple environment variable that is only present when the test suite runs should mitigate this problem.

(b) `JSON.stringify()` will ignore values that do not correspond to JSON compatible values (i.e. object, array, number, string, boolean).