### PR TITLE
Ensure we do not 'append' jwt tokens but set them.

### DIFF
--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -1581,7 +1581,7 @@ export class Formio {
       }
 
       // Handle fetch results
-      const token = response.headers.get('x-jwt-token');
+      const respToken = response.headers.get('x-jwt-token');
 
       // In some strange cases, the fetch library will return an x-jwt-token without sending
       // one to the server. This has even been debugged on the server to verify that no token
@@ -1591,7 +1591,7 @@ export class Formio {
       if (
         (method === 'GET') &&
         !requestToken &&
-        token &&
+        respToken &&
         !opts.external &&
         !url.includes('token=') &&
         !url.includes('x-jwt-token=')
@@ -1603,11 +1603,14 @@ export class Formio {
       if (
         response.status >= 200 &&
         response.status < 300 &&
-        token &&
-        token !== '' &&
+        respToken &&
+        respToken !== '' &&
         !tokenIntroduced
       ) {
-        Formio.setToken(token, opts);
+        Formio.setToken(respToken, {
+          ...opts,
+          ...{ fromCurrent: !token }
+        });
       }
       // 204 is no content. Don't try to .json() it.
       if (response.status === 204) {

--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -1609,7 +1609,7 @@ export class Formio {
       ) {
         Formio.setToken(respToken, {
           ...opts,
-          ...{ fromCurrent: !token }
+          ...{ fromCurrent: (opts.fromCurrent || !!requestToken) }
         });
       }
       // 204 is no content. Don't try to .json() it.

--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -1527,7 +1527,7 @@ export class Formio {
     });
     const token = Formio.getToken(opts);
     if (token && !opts.noToken) {
-      headers.append('x-jwt-token', token);
+      headers.set('x-jwt-token', token);
     }
 
     // The fetch-ponyfill can't handle a proper Headers class anymore. Change it back to an object.


### PR DESCRIPTION
I found a pretty nasty bug with the ```getTempToken``` method where it would call the "current" endpoint with a double JWT token which makes the request fail with Bad Token.

The problem is the code @ https://github.com/formio/core/blob/master/src/sdk/Formio.ts#L1183 calls makeRequest with a new Headers object. A jwt-token is then added to that token @ https://github.com/formio/core/blob/master/src/sdk/Formio.ts#L1530.

This then completes the request, where a new jwt token is returned and calls setToken @ https://github.com/formio/core/blob/master/src/sdk/Formio.ts#L1610C16-L1610C24 and passes the opts that still contains the "header" option from the original request.

This sets the token and then calls "currentUser" @ https://github.com/formio/core/blob/master/src/sdk/Formio.ts#L1766 which then goes back into makeRequest @ https://github.com/formio/core/blob/master/src/sdk/Formio.ts#L2047. 

This then sets the header again which "appends" the jwt-token with the original one.

This sends a request to the server which responds with Bad Token.

This solution solves this by doing 2 things:

 1.) Do not append the jwt-token to the headers, but rather set the header.
 2.) Pass the option "fromCurrent" to the currentUser method so that it does not have to re-fetch the user from the api.

