### PR TITLE
scopes updated and other little updates

### DIFF
--- a/src/process/calculation/index.ts
+++ b/src/process/calculation/index.ts
@@ -12,13 +12,18 @@ export const shouldCalculate = (context: CalculationContext): boolean => {
 };
 
 export const calculateProcessSync: ProcessorFnSync<CalculationScope> = (context: CalculationContext) => {
-    const { component, row, evalContext, scope } = context;
+    const { component, row, evalContext, scope, path } = context;
     if (!shouldCalculate(context)) {
         return;
     }
     const evalContextValue = evalContext ? evalContext(context) : context;
     evalContextValue.value = null;
+    if (!scope.calculated) scope.calculated = [];
     scope.value = Evaluator.evaluate(component.calculateValue, evalContextValue, 'value');
+    scope.calculated.push({
+        path,
+        value: Evaluator.evaluate(component.calculateValue, evalContextValue, 'value')
+    });
     _set(row, component.key, scope.value);
     return;
 };

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -131,10 +131,12 @@ export const conditionProcess: ProcessorFn<ConditionsScope> = async (context: Co
 };
 
 export const conditionProcessSync: ProcessorFnSync<ConditionsScope> = (context: ConditionsContext) => {
-    const { component, row, scope } = context;
+    const { component, row, scope, path } = context;
     scope.conditionallyHidden = component.conditionallyHidden = isConditionallyHidden(context);
+    if (!scope.conditionals) scope.conditionals = [];
     if (component.conditionallyHidden && component.clearOnHide) {
         unset(row, component.key);
+        scope.conditionals.push({ path });
     }
 }; 
 

--- a/src/process/defaultValue/index.ts
+++ b/src/process/defaultValue/index.ts
@@ -29,19 +29,29 @@ export const defaultValueProcess: ProcessorFn<ConditionsScope> = async (context:
 };
 
 export const defaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (context: DefaultValueContext) => {
-    const { component, row, evalContext, scope } = context;
+    const { component, row, evalContext, scope, path } = context;
+    if (!scope.defaultValues) scope.defaultValues = [];
     if (has(row, component.key)) {
         return;
     }
+    let defaultValue = null;
     if (component.defaultValue) {
-        scope.defaultValue = component.defaultValue;
+        defaultValue = component.defaultValue;
+        scope.defaultValues.push({
+            path,
+            value: defaultValue
+        });
     }
     else if (component.customDefaultValue) {
         const evalContextValue = evalContext ? evalContext(context) : context;
         evalContextValue.value = null;
-        scope.defaultValue = Evaluator.evaluate(component.customDefaultValue, evalContextValue, 'value');
+        defaultValue = Evaluator.evaluate(component.customDefaultValue, evalContextValue, 'value');
+        scope.defaultValues.push({
+            path,
+            value: defaultValue
+        });
     }
-    set(row, component.key, scope.defaultValue);
+    set(row, component.key, defaultValue);
 };
 
 export const defaultValueProcessInfo: ProcessorInfo<DefaultValueContext, void> = {

--- a/src/process/fetch/index.ts
+++ b/src/process/fetch/index.ts
@@ -12,7 +12,7 @@ export const shouldFetch = (context: FetchContext): boolean => {
 };
 
 export const fetchProcess: ProcessorFn<FetchScope> = async (context: FetchContext) => {
-    const { component, row, fetch, evalContext } = context;
+    const { component, row, fetch, evalContext, path, scope } = context;
     if (!fetch) {
         console.log('You must provide a fetch interface to the fetch processor.');
         return;
@@ -20,6 +20,7 @@ export const fetchProcess: ProcessorFn<FetchScope> = async (context: FetchContex
     if (!shouldFetch(context)) {
         return;
     }
+    if (!scope.fetched) scope.fetched = [];
     const evalContextValue = evalContext ? evalContext(context) : context;
     const url = Evaluator.interpolateString(get(component, 'fetch.url', ''), evalContextValue);
     if (!url) {
@@ -60,6 +61,10 @@ export const fetchProcess: ProcessorFn<FetchScope> = async (context: FetchContex
             ...evalContextValue, 
             ...{responseData: result}
         }, 'value') : result);
+        scope.fetched.push({
+            path,
+            value: get(row, component.key)
+        });
     }
     catch (err: any) {
         console.log(err.message);

--- a/src/process/populate/index.ts
+++ b/src/process/populate/index.ts
@@ -17,7 +17,7 @@ export const populateProcessSync: ProcessorFnSync<PopulateScope> = (context: Pop
                 scope.row = get(data, compDataPath)[0];
                 scope.populated.push({
                     path,
-                    value: get(data, compDataPath)
+                    row: get(data, compDataPath)[0]
                 });
             }
             break;
@@ -28,7 +28,7 @@ export const populateProcessSync: ProcessorFnSync<PopulateScope> = (context: Pop
                 scope.row = get(data, compDataPath);
                 scope.populated.push({
                     path,
-                    value: get(data, compDataPath)
+                    row: get(data, compDataPath)
                 });
             }
             break;

--- a/src/process/populate/index.ts
+++ b/src/process/populate/index.ts
@@ -9,11 +9,16 @@ export const populateProcessSync: ProcessorFnSync<PopulateScope> = (context: Pop
     const { data } = scope;
     const compDataPath = componentDataPath(component, getContextualRowPath(path));
     const compData: any = get(data, compDataPath);
+    if (!scope.populated) scope.populated = [];
     switch (getModelType(component)) {
         case 'array':
             if (!compData || !compData.length) {
                 set(data, compDataPath, [{}]);
                 scope.row = get(data, compDataPath)[0];
+                scope.populated.push({
+                    path,
+                    value: get(data, compDataPath)
+                });
             }
             break;
         case 'dataObject':
@@ -21,6 +26,10 @@ export const populateProcessSync: ProcessorFnSync<PopulateScope> = (context: Pop
             if (!compData || typeof compData !== 'object') {
                 set(data, compDataPath, {});
                 scope.row = get(data, compDataPath);
+                scope.populated.push({
+                    path,
+                    value: get(data, compDataPath)
+                });
             }
             break;
     }

--- a/src/process/processReduce.ts
+++ b/src/process/processReduce.ts
@@ -71,9 +71,10 @@ export function processReduce(context: BaseProcessContext<ReducerScope>): Reduce
                     scope.processes[processorName] = [];
                 }
                 scope.processes[processorName].push({
-                    ...component, 
-                    ...{path}
-                });
+                    ...component,
+                    path,
+                    components: null,
+                } as any);
             }
         }
     });
@@ -82,7 +83,10 @@ export function processReduce(context: BaseProcessContext<ReducerScope>): Reduce
 }
 
 // Process a reduced set of processes and components.
-export function processReducedSync(context: ReducedProcessContext<ProcessorsScope>) {
+export function processReducedSync(context: ReducedProcessContext<ProcessorsScope>): ProcessorsScope {
+    if (!context.scope) {
+        context.scope = {} as ProcessorsScope;
+    }
     const { scope, processes } = context;
     ProcessorOrder.forEach((processorName: string) => {
         if (processes.hasOwnProperty(processorName) && ProcessorMap.hasOwnProperty(processorName)) {
@@ -99,7 +103,10 @@ export function processReducedSync(context: ReducedProcessContext<ProcessorsScop
 }
 
 // Asynchronoously process a reduced set of processes and components.
-export async function processReduced(context: ReducedProcessContext<ProcessorsScope>) {
+export async function processReduced(context: ReducedProcessContext<ProcessorsScope>): Promise<ProcessorsScope> {
+    if (!context.scope) {
+        context.scope = {} as ProcessorsScope;
+    }
     const { scope, processes } = context;
     for (const processorName of ProcessorOrder) {
         if (processes.hasOwnProperty(processorName) && ProcessorMap.hasOwnProperty(processorName)) {

--- a/src/types/process/calculation/CalculationScope.ts
+++ b/src/types/process/calculation/CalculationScope.ts
@@ -1,4 +1,8 @@
 import { ProcessorScope } from "..";
 export type CalculationScope = {
     value?: any;
+    calculated?: Array<{
+        path: string;
+        value: any;
+    }>;
 } & ProcessorScope;

--- a/src/types/process/conditions/ConditionsScope.ts
+++ b/src/types/process/conditions/ConditionsScope.ts
@@ -1,4 +1,7 @@
 import { ProcessorScope } from "..";
 export type ConditionsScope = {
     conditionallyHidden?: any;
+    conditionals?: Array<{
+        path: string;
+    }>;
 } & ProcessorScope;

--- a/src/types/process/defaultValue/DefaultValueScope.ts
+++ b/src/types/process/defaultValue/DefaultValueScope.ts
@@ -1,4 +1,8 @@
 import { ProcessorScope } from "..";
 export type DefaultValueScope = {
     defaultValue?: any;
+    defaultValues?: Array<{
+        path: string;
+        value: any;
+    }>;
 } & ProcessorScope;

--- a/src/types/process/fetch/FetchScope.ts
+++ b/src/types/process/fetch/FetchScope.ts
@@ -1,3 +1,7 @@
 import { ProcessorScope } from "..";
 export type FetchScope = {
+  fetched?: Array<{
+    path: string;
+    value: any;
+  }>;
 } & ProcessorScope;

--- a/src/types/process/populate/PopulateScope.ts
+++ b/src/types/process/populate/PopulateScope.ts
@@ -2,4 +2,8 @@ import { ProcessorScope } from "..";
 export type PopulateScope = {
     data: any;
     row?: any;
+    populated?: Array<{
+        path: string;
+        value: any;
+    }>;
 } & ProcessorScope;

--- a/src/types/process/populate/PopulateScope.ts
+++ b/src/types/process/populate/PopulateScope.ts
@@ -4,6 +4,6 @@ export type PopulateScope = {
     row?: any;
     populated?: Array<{
         path: string;
-        value: any;
+        row: any;
     }>;
 } & ProcessorScope;

--- a/src/types/process/validation/ValidationScope.ts
+++ b/src/types/process/validation/ValidationScope.ts
@@ -2,4 +2,8 @@ import { FieldError } from "error";
 import { ProcessorScope } from "..";
 export type ValidationScope = ProcessorScope & {
     errors: FieldError[];
+    validated?: Array<{
+        path: string;
+        error: FieldError;
+    }>;
 };


### PR DESCRIPTION
Updated:
- Processor scopes to contain affected components
- Removed components array from component when it's pushed to processors output
- Certain properties picked from validation error context
- `scope` default value added to processReduced, so it's not required to pass it