### PR TITLE
FIO-7883: include premium components in 'multiple' validation conditional

### DIFF
--- a/src/process/validation/rules/__tests__/validateMultiple.test.ts
+++ b/src/process/validation/rules/__tests__/validateMultiple.test.ts
@@ -1,0 +1,382 @@
+import { Component, TextAreaComponent, ValidationContext } from 'types';
+import { expect } from 'chai';
+
+import { isEligible, emptyValueIsArray, validateMultipleSync } from '../validateMultiple';
+import { FieldError } from 'error';
+
+describe('validateMultiple', () => {
+    describe('isEligible', () => {
+        it('should return false for hidden component with multiple', () => {
+            const component: Component = {
+                type: 'hidden',
+                input: true,
+                key: 'hidden',
+            };
+            expect(isEligible(component)).to.be.false;
+        });
+
+        it('should return false for address component if not multiple', () => {
+            const component: Component = {
+                type: 'address',
+                input: true,
+                key: 'address',
+            };
+            expect(isEligible(component)).to.be.false;
+        });
+
+        it('should return true for address component if multiple', () => {
+            const component: Component = {
+                type: 'address',
+                input: true,
+                key: 'address',
+                multiple: true,
+            };
+            expect(isEligible(component)).to.be.true;
+        });
+
+        it('should return false for textArea component with as !== json', () => {
+            const component: TextAreaComponent = {
+                type: 'textArea',
+                as: 'text',
+                input: true,
+                key: 'textArea',
+                multiple: true,
+                rows: 4,
+                wysiwyg: true,
+                editor: 'ckeditor',
+                fixedSize: true,
+                inputFormat: 'plain',
+            };
+            expect(isEligible(component)).to.be.false;
+        });
+
+        it('should return true for textArea component with as === json', () => {
+            const component: TextAreaComponent = {
+                type: 'textArea',
+                as: 'json',
+                input: true,
+                key: 'textAreaJson',
+                multiple: true,
+                rows: 4,
+                wysiwyg: true,
+                editor: 'ckeditor',
+                fixedSize: true,
+                inputFormat: 'plain',
+            };
+            expect(isEligible(component)).to.be.true;
+        });
+
+        it('should return true for other component types', () => {
+            const component: Component = {
+                type: 'textfield',
+                input: true,
+                key: 'textfield',
+                multiple: true,
+            };
+            expect(isEligible(component)).to.be.true;
+        });
+    });
+
+    describe('emptyValueIsArray', () => {
+        it('should return true for datagrid component', () => {
+            const component: Component = {
+                type: 'datagrid',
+                input: true,
+                key: 'datagrid',
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return true for editgrid component', () => {
+            const component: Component = {
+                type: 'editgrid',
+                input: true,
+                key: 'editgrid',
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return true for tagpad component', () => {
+            const component: Component = {
+                type: 'tagpad',
+                input: true,
+                key: 'tagpad',
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return true for sketchpad component', () => {
+            const component: Component = {
+                type: 'sketchpad',
+                input: true,
+                key: 'sketchpad',
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return true for datatable component', () => {
+            const component: Component = {
+                type: 'datatable',
+                input: true,
+                key: 'datatable',
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return true for dynamicWizard component', () => {
+            const component: Component = {
+                type: 'dynamicWizard',
+                input: true,
+                key: 'dynamicWizard',
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return true for file component', () => {
+            const component: Component = {
+                type: 'file',
+                input: true,
+                key: 'file',
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return false for select component without multiple', () => {
+            const component: Component = {
+                type: 'select',
+                input: true,
+                key: 'select',
+            };
+            expect(emptyValueIsArray(component)).to.be.false;
+        });
+
+        it('should return true for select component with multiple', () => {
+            const component: Component = {
+                type: 'select',
+                input: true,
+                key: 'select',
+                multiple: true,
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return true for tags component with storeas !== string', () => {
+            const component: Component = {
+                type: 'tags',
+                input: true,
+                key: 'tags',
+                storeas: 'array',
+            };
+            expect(emptyValueIsArray(component)).to.be.true;
+        });
+
+        it('should return false for tags component with storeas === string', () => {
+            const component: Component = {
+                type: 'tags',
+                input: true,
+                key: 'tags',
+                storeas: 'string',
+            };
+            expect(emptyValueIsArray(component)).to.be.false;
+        });
+
+        it('should return false for other component types', () => {
+            const component: Component = {
+                type: 'textfield',
+                input: true,
+                key: 'textfield',
+            };
+            expect(emptyValueIsArray(component)).to.be.false;
+        });
+    });
+
+    describe('validateMultipleSync', () => {
+        describe('values that should be arrays', () => {
+            it('should return an error for a select component with multiple that is not an array', () => {
+                const component: Component = {
+                    type: 'select',
+                    input: true,
+                    key: 'select',
+                    multiple: true,
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        select: 'foo',
+                    },
+                    value: 'foo',
+                    row: {
+                        select: 'foo'
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.instanceOf(FieldError);
+            });
+
+            it('should return null for a select component with multiple that is an array', () => {
+                const component: Component = {
+                    type: 'select',
+                    input: true,
+                    key: 'select',
+                    multiple: true,
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        select: ['foo'],
+                    },
+                    value: ['foo'],
+                    row: {
+                        select: 'foo'
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.null;
+            });
+
+            it('should return an error for a select component without multiple that is an array', () => {
+                const component: Component = {
+                    type: 'select',
+                    input: true,
+                    key: 'select',
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        select: ['foo'],
+                    },
+                    value: ['foo'],
+                    row: {
+                        select: ['foo']
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.instanceOf(FieldError);
+            });
+
+            it('should return null for a select component without multiple that is not an array', () => {
+                const component: Component = {
+                    type: 'select',
+                    input: true,
+                    key: 'select',
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        select: 'foo',
+                    },
+                    value: 'foo',
+                    row: {
+                        select: 'foo'
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.null;
+            });
+
+            it('should return null for a sketchpad component', () => {
+                const component: Component = {
+                    type: 'sketchpad',
+                    input: true,
+                    key: 'sketchpad',
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        sketchpad: ['foo'],
+                    },
+                    value: ['foo'],
+                    row: {
+                        sketchpad: ['foo']
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.null;
+            });
+
+            it('should return null for a tagpad component', () => {
+                const component: Component = {
+                    type: 'sketchpad',
+                    input: true,
+                    key: 'tagpad',
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        tagpad: ['foo'],
+                    },
+                    value: ['foo'],
+                    row: {
+                        tagpad: ['foo']
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.null;
+            });
+
+            it('should return null for a data table component', () => {
+                const component: Component = {
+                    type: 'datatable',
+                    input: true,
+                    key: 'datatable',
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        [component.key]: ['foo'],
+                    },
+                    value: ['foo'],
+                    row: {
+                        [component.key]: ['foo']
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.null;
+            });
+
+            it('should return null for a dynamic wizard component', () => {
+                const component: Component = {
+                    type: 'dynamicWizard',
+                    input: true,
+                    key: 'dynamicwizard',
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        [component.key]: ['foo'],
+                    },
+                    value: ['foo'],
+                    row: {
+                        [component.key]: ['foo']
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.null;
+            });
+        });
+    });
+});

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -1,14 +1,12 @@
 import { isNil } from 'lodash';
 import { FieldError } from 'error';
-import { Component, TextAreaComponent, RuleFn, TagsComponent, RuleFnSync, ValidationContext } from 'types';
+import { Component, TextAreaComponent, RuleFn, TagsComponent, RuleFnSync, ValidationContext, DataObject } from 'types';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 
 const isEligible = (component: Component) => {
     // TODO: would be nice if this was type safe
     switch (component.type) {
         case 'hidden':
-        case 'select':
-            return false;
         case 'address':
             if (!component.multiple) {
                 return false;
@@ -25,13 +23,14 @@ const isEligible = (component: Component) => {
 }
 
 const emptyValueIsArray = (component: Component) => {
-    // TODO: yikes, this could be better
+    // TODO: How do we infer the data model of the compoennt given only its JSON? For now, we have to hardcode component types
     switch (component.type) {
         case 'datagrid':
         case 'editgrid':
         case 'tagpad':
         case 'sketchpad':
         case 'datatable':
+        case 'dynamicWizard':
         case 'file':
             return true;
         case 'select':
@@ -63,9 +62,8 @@ export const validateMultipleSync: RuleFnSync = (context: ValidationContext) => 
     }
 
     const shouldBeArray = !!component.multiple;
-    const canBeArray = emptyValueIsArray(component);
-    const isArray = Array.isArray(value);
     const isRequired = !!component.validate?.required;
+    const isArray = Array.isArray(value);
 
     if (shouldBeArray) {
         if (isArray) {
@@ -75,6 +73,7 @@ export const validateMultipleSync: RuleFnSync = (context: ValidationContext) => 
             return isNil(value) ? isRequired ? new FieldError('array', {...context, setting: true}) : null : null;
         }
     } else {
+        const canBeArray = emptyValueIsArray(component);
         if (!canBeArray && isArray) {
             return new FieldError('nonarray', {...context, setting: false});
         }

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -29,6 +29,9 @@ const emptyValueIsArray = (component: Component) => {
     switch (component.type) {
         case 'datagrid':
         case 'editgrid':
+        case 'tagpad':
+        case 'sketchpad':
+        case 'datatable':
         case 'file':
             return true;
         case 'select':

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -3,7 +3,7 @@ import { FieldError } from 'error';
 import { Component, TextAreaComponent, RuleFn, TagsComponent, RuleFnSync, ValidationContext, DataObject } from 'types';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 
-const isEligible = (component: Component) => {
+export const isEligible = (component: Component) => {
     // TODO: would be nice if this was type safe
     switch (component.type) {
         case 'hidden':
@@ -11,18 +11,18 @@ const isEligible = (component: Component) => {
             if (!component.multiple) {
                 return false;
             }
-            break;
+            return true;
         case 'textArea':
             if (!(component as TextAreaComponent).as || (component as TextAreaComponent).as !== 'json') {
                 return false;
             }
-            break;
+            return true;
         default:
             return true;
     }
 }
 
-const emptyValueIsArray = (component: Component) => {
+export const emptyValueIsArray = (component: Component) => {
     // TODO: How do we infer the data model of the compoennt given only its JSON? For now, we have to hardcode component types
     switch (component.type) {
         case 'datagrid':
@@ -69,8 +69,9 @@ export const validateMultipleSync: RuleFnSync = (context: ValidationContext) => 
         if (isArray) {
             return isRequired ? value.length > 0 ? null : new FieldError('array_nonempty', {...context, setting: true}): null;
         } else {
+            const error = new FieldError('array', {...context, setting: true});
             // Null/undefined is ok if this value isn't required; anything else should fail
-            return isNil(value) ? isRequired ? new FieldError('array', {...context, setting: true}) : null : null;
+            return isNil(value) ? isRequired ? error : null : error;
         }
     } else {
         const canBeArray = emptyValueIsArray(component);


### PR DESCRIPTION
Previously, the "multiple" validation rule didn't account for certain premium components having an array data model. This PR accomplishes the easy fix: adding the component types to the multiple validation conditional that decides if that component needs to be validated as an array.

*However*, this raises a vital question: how do we infer a component’s data model from its JSON schema? Simply adding component types to a switch statement doesn't cover, for example, custom components.