### PR TITLE
FIO-7958: add normalize processor fn and derive context.value rather than mutate it directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.0.0-dev.bb.8",
+  "version": "2.0.0-dev.bb.9",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.0.0-dev.bb.13",
+  "version": "2.0.0-dev.4",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.0.0-dev.bb.12",
+  "version": "2.0.0-dev.bb.13",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.0.0-dev.bb.11",
+  "version": "2.0.0-dev.bb.12",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.0.0-dev.bb.7",
+  "version": "2.0.0-dev.bb.8",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.0.0-dev.4",
+  "version": "2.0.0-dev.bb.7",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.0.0-dev.bb.9",
+  "version": "2.0.0-dev.bb.11",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/src/process/calculation/index.ts
+++ b/src/process/calculation/index.ts
@@ -1,13 +1,12 @@
 import JSONLogic from 'modules/jsonlogic';
 import { ProcessorFn, ProcessorFnSync, CalculationScope, CalculationContext, ProcessorInfo, FilterScope } from 'types';
 import _set from 'lodash/set';
-import { getComponentKey } from 'utils/formUtil';
 const Evaluator = JSONLogic.evaluator;
 
 export const shouldCalculate = (context: CalculationContext): boolean => {
     const { component, config } = context;
     if (
-        !component.calculateValue || 
+        !component.calculateValue ||
         (config?.server && !component.calculateServer)
     ) {
         return false;
@@ -16,7 +15,7 @@ export const shouldCalculate = (context: CalculationContext): boolean => {
 };
 
 export const calculateProcessSync: ProcessorFnSync<CalculationScope> = (context: CalculationContext) => {
-    const { component, row, evalContext, scope, path, value } = context;
+    const { component, data, evalContext, scope, path } = context;
     if (!shouldCalculate(context)) {
         return;
     }
@@ -31,8 +30,7 @@ export const calculateProcessSync: ProcessorFnSync<CalculationScope> = (context:
             path,
             value: newValue
         });
-        _set(row, getComponentKey(component), newValue);
-        context.value = newValue;
+        _set(data, path, newValue);
     }
     return;
 };

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -2,10 +2,10 @@ import { ProcessorFn, ProcessorFnSync, ConditionsScope, ProcessorInfo, Condition
 import { Utils } from 'utils';
 import unset from 'lodash/unset';
 import { componentInfo, getComponentKey, getComponentPath } from 'utils/formUtil';
-import { 
-    checkCustomConditional, 
-    checkJsonConditional, 
-    checkLegacyConditional, 
+import {
+    checkCustomConditional,
+    checkJsonConditional,
+    checkLegacyConditional,
     checkSimpleConditional,
     isLegacyConditional,
     isSimpleConditional,
@@ -98,7 +98,7 @@ export const isConditionallyHidden = (context: ConditionsContext): boolean => {
 
 export type ConditionallyHidden = (context: ConditionsContext) => boolean;
 export const conditionalProcess = (context: ConditionsContext, isHidden: ConditionallyHidden) => {
-    const { component, row, scope, path } = context;
+    const { component, data, row, scope, path } = context;
     const conditionallyHidden = isHidden(context);
     if (!scope.conditionals) scope.conditionals = [];
     if (conditionallyHidden) {
@@ -115,8 +115,7 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
         else {
             scope.conditionals.push({ path, conditionallyHidden: true });
             if (!component.hasOwnProperty('clearOnHide') || component.clearOnHide) {
-                unset(row, getComponentKey(component));
-                context.value = undefined;
+                unset(data, path);
             }
         }
     }

--- a/src/process/defaultValue/index.ts
+++ b/src/process/defaultValue/index.ts
@@ -30,7 +30,7 @@ export const customDefaultValueProcess: ProcessorFn<ConditionsScope> = async (co
 };
 
 export const customDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (context: DefaultValueContext) => {
-    const { component, row, scope, evalContext, path } = context;
+    const { component, row, data, scope, evalContext, path } = context;
     if (!hasCustomDefaultValue(context)) {
         return;
     }
@@ -52,7 +52,7 @@ export const customDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
         });
     }
     if (defaultValue !== null && defaultValue !== undefined) {
-        set(row, getComponentKey(component), defaultValue);
+        set(data, path, defaultValue);
     }
 };
 
@@ -61,7 +61,7 @@ export const serverDefaultValueProcess: ProcessorFn<ConditionsScope> = async (co
 };
 
 export const serverDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (context: DefaultValueContext) => {
-    const { component, row, scope, path } = context;
+    const { component, row, data, scope, path } = context;
     if (!hasServerDefaultValue(context)) {
         return;
     }
@@ -84,8 +84,7 @@ export const serverDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
         });
     }
     if (defaultValue !== null && defaultValue !== undefined) {
-        set(row, getComponentKey(component), defaultValue);
-        context.value = defaultValue;
+        set(data, path, defaultValue);
     }
 };
 

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -3,7 +3,8 @@ import set from 'lodash/set';
 import { Utils } from "utils";
 import { get, isObject } from "lodash";
 export const filterProcessSync: ProcessorFnSync<FilterScope> = (context: FilterContext) => {
-    const { scope, value, path, component, data } = context;
+    const { scope, path, component, data } = context;
+    let { value } = context;
     if (!scope.filter) scope.filter = {};
     if (value !== undefined) {
         const modelType = Utils.getModelType(component);
@@ -19,10 +20,6 @@ export const filterProcessSync: ProcessorFnSync<FilterScope> = (context: FilterC
                 }
                 break;
             default:
-                // Make sure to set the value as an array if the component is a multi-value component.
-                if (component.multiple && value && !Array.isArray(value)) {
-                    set(data, path, [value]);
-                }
                 scope.filter[path] = true;
                 break;
         }

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -8,3 +8,4 @@ export * from './logic';
 export * from './populate';
 export * from './processOne';
 export * from './process';
+export * from './normalize';

--- a/src/process/normalize/index.ts
+++ b/src/process/normalize/index.ts
@@ -1,0 +1,289 @@
+import get from 'lodash/get';
+import set from 'lodash/set';
+import isString from 'lodash/isString';
+import toString from 'lodash/toString';
+import isNil from 'lodash/isNil';
+import isObject from 'lodash/isObject';
+import {
+    AddressComponent,
+    DayComponent,
+    EmailComponent,
+    ProcessorFnSync,
+    ProcessorFn,
+    RadioComponent,
+    RecaptchaComponent,
+    SelectComponent,
+    SelectBoxesComponent,
+    TagsComponent,
+    TextFieldComponent,
+    DefaultValueScope,
+    ProcessorInfo,
+    ProcessorContext
+} from "types";
+
+type NormalizeScope = DefaultValueScope;
+
+const isAddressComponent = (component: any): component is AddressComponent => component.type === "address";
+const isDayComponent = (component: any): component is DayComponent => component.type === "day";
+const isEmailComponent = (component:any): component is EmailComponent => component.type === "email";
+const isRadioComponent = (component: any): component is RadioComponent => component.type === "radio";
+const isRecaptchaComponent = (component: any): component is RecaptchaComponent => component.type === "recaptcha";
+const isSelectComponent = (component: any): component is SelectComponent => component.type === "select";
+const isSelectBoxesComponent = (component: any): component is SelectBoxesComponent => component.type === "selectboxes";
+const isTagsComponent = (component: any): component is TagsComponent => component.type === "tags";
+const isTextFieldComponent = (component: any): component is TextFieldComponent => component.type === "textfield";
+
+const normalizeAddressComponentValue = (component: AddressComponent, value: any) => {
+    if (!component.multiple && Boolean(component.enableManualMode) && value && value.mode) {
+        return {
+          mode: 'autocomplete',
+          address: value,
+        }
+    }
+    return value;
+}
+
+const getLocaleDateFormatInfo = (locale: string = 'en') => {
+    const formatInfo: {dayFirst?: boolean} = {};
+
+    const day = 21;
+    const exampleDate = new Date(2017, 11, day);
+    const localDateString = exampleDate.toLocaleDateString(locale);
+
+    formatInfo.dayFirst = localDateString.slice(0, 2) === day.toString();
+
+    return formatInfo;
+};
+
+const getLocaleDayFirst = (component: DayComponent, form: any) => {
+    if (component.useLocaleSettings) {
+        return getLocaleDateFormatInfo(form.options?.language).dayFirst;
+    }
+    return component.dayFirst;
+};
+
+const normalizeDayComponentValue = (component: DayComponent, form: any, value: any) => {
+    // TODO: this is a quick and dirty port of the Day component's normalizeValue method, may need some updates
+    const valueMask = /^\d{2}\/\d{2}\/\d{4}$/;
+
+    const isDayFirst = getLocaleDayFirst(component, form);
+    const showDay = !get(component, 'fields.day.hide', false);
+    const showMonth = !get(component, 'fields.month.hide', false);
+    const showYear = !get(component, 'fields.year.hide', false);
+
+    if (!value || valueMask.test(value)) {
+        return value;
+    }
+    let dateParts: string[] = [];
+    const valueParts = value.split('/');
+    const [DAY, MONTH, YEAR] = component.dayFirst ? [0, 1, 2] : [1, 0, 2];
+    const defaultValue = component.defaultValue ? component.defaultValue.split('/') : '';
+
+    const getNextPart = (shouldTake: boolean, defaultValue: string) =>
+        dateParts.push(shouldTake ? valueParts.shift() : defaultValue);
+
+    if (isDayFirst) {
+        getNextPart(showDay, defaultValue ? defaultValue[DAY] : '00');
+    }
+
+    getNextPart(showMonth, defaultValue ? defaultValue[MONTH] : '00');
+
+    if (!isDayFirst) {
+        getNextPart(showDay, defaultValue ? defaultValue[DAY] : '00');
+    }
+
+    getNextPart(showYear, defaultValue ? defaultValue[YEAR] : '0000');
+
+    return dateParts.join('/');
+};
+
+const normalizeRadioComponentValue = (value: any) => {
+    const isEquivalent = toString(value) === Number(value).toString();
+    if (!isNaN(parseFloat(value)) && isFinite(value) && isEquivalent) {
+        return +value;
+    }
+
+    if (value === 'true') {
+        return true;
+    }
+    if (value === 'false') {
+       return false;
+    }
+
+    return value;
+};
+
+const normalizeSingleSelectComponentValue = (component: SelectComponent, value: any) => {
+    if (isNil(value)) {
+        return;
+    }
+    const valueIsObject = isObject(value);
+    //check if value equals to default emptyValue
+    if (valueIsObject && Object.keys(value).length === 0) {
+        return value;
+    }
+
+    const dataType = component.dataType || 'auto';
+    const normalize = {
+        value,
+        number() {
+            const numberValue = Number(this.value);
+            const isEquivalent = value.toString() === numberValue.toString();
+
+            if (!Number.isNaN(numberValue) && Number.isFinite(numberValue) && value !== '' && isEquivalent) {
+                this.value = numberValue;
+            }
+
+            return this;
+        },
+
+        boolean() {
+            if (isString(this.value) && (this.value.toLowerCase() === 'true' || this.value.toLowerCase() === 'false')) {
+                this.value = (this.value.toLowerCase() === 'true');
+            }
+            return this;
+        },
+
+        string() {
+            this.value = String(this.value);
+            return this;
+        },
+
+        object() {
+            return this;
+        },
+
+        auto() {
+            if (isObject(this.value)) {
+                this.value = this.object().value;
+            }
+            else {
+                this.value = this.string().number().boolean().value;
+            }
+            return this;
+        }
+    };
+
+    try {
+        return normalize[dataType]().value;
+    }
+    catch (err) {
+        console.warn('Failed to normalize value', err);
+        return value;
+    }
+}
+
+const normalizeSelectComponentValue = (component: SelectComponent, value: any) => {
+    if (component.multiple && Array.isArray(value)) {
+        return value.map((singleValue) => normalizeSingleSelectComponentValue(component, singleValue));
+    }
+
+    return normalizeSingleSelectComponentValue(component, value);
+};
+
+const normalizeSelectBoxesComponentValue = (value: any) => {
+    if (typeof value !== 'object') {
+        if (typeof value === 'string') {
+            return {
+                [value]: true
+            };
+        }
+        else {
+            return {};
+        }
+    }
+    if (Array.isArray(value)) {
+        return value.reduce((acc, curr) => {
+            return { ...acc, [curr]: true };
+        }, {});
+    }
+
+    return value;
+};
+
+const normalizeTagsComponentValue = (component: TagsComponent, value: any) => {
+    const delimiter = component.delimeter || ',';
+    if (component.storeas === 'string' && Array.isArray(value)) {
+        return value.join(delimiter);
+    }
+    else if (component.storeas === 'array' && typeof value === 'string') {
+        return value.split(delimiter).filter(result => result);
+    }
+    return value;
+};
+
+const normalizeMaskValue = (
+    component: TextFieldComponent,
+    defaultValues: DefaultValueScope['defaultValues'],
+    value: any
+) => {
+    if (component.inputMasks && component.inputMasks.length > 0) {
+        if (!value || typeof value !== 'object') {
+            return {
+                val: value,
+                maskName: component.inputMasks[0].label
+            }
+        }
+        if (!value.value) {
+            const defaultValue = defaultValues?.find((defaultValue) => defaultValue.path === component.path);
+            value.value = Array.isArray(defaultValue) && defaultValue.length > 0 ? defaultValue[0] : defaultValue;
+        }
+    }
+    return value;
+}
+
+const normalizeTextFieldComponentValue = (
+    component: TextFieldComponent,
+    defaultValues: DefaultValueScope['defaultValues'],
+    value: any
+) => {
+    if (component.allowMultipleMasks && component.inputMasks && component.inputMasks.length > 0) {
+        if (Array.isArray(value)) {
+            return value.map((val) => normalizeMaskValue(component, defaultValues, val));
+        } else {
+            return normalizeMaskValue(component, defaultValues, value);
+        }
+    }
+    return value;
+}
+
+export const normalizeProcess: ProcessorFn<NormalizeScope> = async (context) => {
+    return normalizeProcessSync(context);
+}
+
+export const normalizeProcessSync: ProcessorFnSync<NormalizeScope> = (context) => {
+    const { component, form, scope, path, data, value } = context;
+    let { defaultValues } = scope;
+    // First check for component-type-specific transformations
+    if (isAddressComponent(component)) {
+        set(data, path, normalizeAddressComponentValue(component, value));
+    } else if (isDayComponent(component)) {
+        set(data, path, normalizeDayComponentValue(component, form, value));
+    } else if (isEmailComponent(component)) {
+        if (value && typeof value === 'string') {
+            set(data, path, value.toLowerCase());
+        }
+    } else if (isRadioComponent(component)) {
+        set(data, path, normalizeRadioComponentValue(value));
+    } else if (isSelectComponent(component)) {
+        set(data, path, normalizeSelectComponentValue(component, value));
+    } else if (isSelectBoxesComponent(component)) {
+        set(data, path, normalizeSelectBoxesComponentValue(value));
+    } else if (isTagsComponent(component)) {
+        set(data, path, normalizeTagsComponentValue(component, value));
+    } else if (isTextFieldComponent(component)) {
+       set(data, path, normalizeTextFieldComponentValue(component, defaultValues, value));
+    }
+
+    // Next perform component-type-agnostic transformations (i.e. super())
+    if (component.multiple && !Array.isArray(value)) {
+        set(data, path, value ? [value] : []);
+    }
+};
+
+export const normalizeProcessInfo: ProcessorInfo<ProcessorContext<NormalizeScope>, void> = {
+    name: 'normalize',
+    shouldProcess: () => true,
+    process: normalizeProcess,
+    processSync: normalizeProcessSync
+}

--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -1,3 +1,5 @@
+import get from "lodash/get";
+import set from "lodash/set";
 import { ProcessContext, ProcessTarget, ProcessorInfo, ProcessorScope } from "types";
 import { eachComponentData, eachComponentDataAsync } from "utils/formUtil";
 import { processOne, processOneSync } from './processOne';
@@ -8,6 +10,7 @@ import { logicProcessInfo } from "./logic";
 import { conditionProcessInfo, customConditionProcessInfo, simpleConditionProcessInfo } from "./conditions";
 import { validateCustomProcessInfo, validateProcessInfo, validateServerProcessInfo } from "./validation";
 import { filterProcessInfo } from "./filter";
+import { normalizeProcessInfo } from "./normalize";
 
 export async function process<ProcessScope>(context: ProcessContext<ProcessScope>): Promise<ProcessScope> {
     const { instances, components, data, scope, flat, processors } = context;
@@ -75,6 +78,7 @@ export const ProcessorMap: Record<string, ProcessorInfo<any, any>> = {
     conditions: conditionProcessInfo,
     customConditions: customConditionProcessInfo,
     simpleConditions: simpleConditionProcessInfo,
+    normalize: normalizeProcessInfo,
     fetch: fetchProcessInfo,
     logic: logicProcessInfo,
     validate: validateProcessInfo,
@@ -86,6 +90,7 @@ export const ProcessTargets: ProcessTarget = {
     submission: [
         filterProcessInfo,
         serverDefaultValueProcessInfo,
+        normalizeProcessInfo,
         fetchProcessInfo,
         simpleConditionProcessInfo,
         validateServerProcessInfo

--- a/src/process/processOne.ts
+++ b/src/process/processOne.ts
@@ -1,4 +1,4 @@
-import { get } from "lodash";
+import { get, set } from "lodash";
 import { Component, DataObject, ProcessorsContext, ProcessorType } from "types";
 import { getComponentKey } from "utils/formUtil";
 
@@ -8,12 +8,22 @@ export function dataValue(component: Component, row: any) {
 }
 
 export async function processOne<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
+    const { processors } = context;
+    // Create a getter for `value` that is always derived from the current data object
+    if (typeof context.value === 'undefined') {
+        Object.defineProperty(context, 'value', {
+            get() {
+                return get(context.data, context.path);
+            },
+            set(newValue: any) {
+                set(context.data, context.path, newValue);
+            }
+        });
+    }
     if (!context.row) {
         return;
     }
-    const { processors } = context;
     context.processor = ProcessorType.Custom;
-    context.value = dataValue(context.component, context.row);
     for (const processor of processors) {
         if (processor?.process) {
             await processor.process(context);
@@ -23,19 +33,24 @@ export async function processOne<ProcessorScope>(context: ProcessorsContext<Proc
 
 export function processOneSync<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
     const { processors, component } = context;
+    // Create a getter for `value` that is always derived from the current data object
+    if (typeof context.value === 'undefined') {
+        Object.defineProperty(context, 'value', {
+            get() {
+                return get(context.data, context.path);
+            },
+            set(newValue: any) {
+                set(context.data, context.path, newValue);
+            }
+        });
+    }
     // Check if the component is in a nested form
     let parent: any = component?.parent;
     while (parent?.type !== "form" && parent !== undefined && parent !== null) {
         parent = parent?.parent;
     }
-    // If the component is in a nested form, set the context data to the parent form data
-    if (parent?.type === "form") {
-        const dataPath = component.path?.replace(`.${component.key}`, '');
-        const data = get(context.data, dataPath ?? '');
-        context.data = data as DataObject;
-    }
+    
     context.processor = ProcessorType.Custom;
-    context.value = dataValue(context.component, context.row);
     processors.forEach((processor) => {
         if (processor?.processSync) {
             processor.processSync(context)

--- a/src/process/validation/rules/__tests__/validateMultiple.test.ts
+++ b/src/process/validation/rules/__tests__/validateMultiple.test.ts
@@ -378,5 +378,30 @@ describe('validateMultiple', () => {
                 expect(validateMultipleSync(context)).to.be.null;
             });
         });
+
+        describe('values that should not be arrays', () => {
+            it('should return an error for a textfield component without multiple that is an array', () => {
+                const component: Component = {
+                    type: 'textfield',
+                    input: true,
+                    key: 'textfield',
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        textfield: ['foo'],
+                    },
+                    value: ['foo'],
+                    row: {
+                        textfield: ['foo']
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.instanceOf(FieldError);
+            });
+        });
     });
 });

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -1,6 +1,6 @@
 import { isNil } from 'lodash';
 import { FieldError } from 'error';
-import { Component, TextAreaComponent, RuleFn, TagsComponent, RuleFnSync, ValidationContext, DataObject } from 'types';
+import { Component, TextAreaComponent, RuleFn, TagsComponent, RuleFnSync, ValidationContext } from 'types';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 
 export const isEligible = (component: Component) => {
@@ -85,6 +85,7 @@ export const validateMultipleSync: RuleFnSync = (context: ValidationContext) => 
 export const validateMultipleInfo: ProcessorInfo<ValidationContext, FieldError | null> = {
     name: 'validateMultiple',
     process: validateMultiple,
+    fullValue: true,
     processSync: validateMultipleSync,
     shouldProcess: shouldValidate,
 };

--- a/src/types/BaseComponent.ts
+++ b/src/types/BaseComponent.ts
@@ -47,6 +47,8 @@ export type BaseComponent = {
     logic?: AdvancedLogic[];
     validateOn?: string;
     validateWhenHidden?: boolean;
+    modelType?: "array" | "value" | "object" | "dataObject" | "inherit" | "value";
+    parentPath?: string;
     validate?: {
         required?: boolean;
         custom?: string;
@@ -59,9 +61,9 @@ export type BaseComponent = {
         json?: any;
         row?: string;
     };
-    conditional?: 
+    conditional?:
         (
-            JSONConditional | 
+            JSONConditional |
             LegacyConditional |
             SimpleConditional
         );

--- a/src/types/Component.ts
+++ b/src/types/Component.ts
@@ -304,7 +304,7 @@ export type ListComponent = BaseComponent & {
     authenticate?: boolean;
     ignoreCache?: boolean;
     template?: string;
-    dataType?: string;
+    dataType?: 'auto' | 'boolean' | 'string' | 'object' | 'number';
     validate?: {
         onlyAvailableItems?: boolean;
     };

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -20,7 +20,7 @@ import { Evaluator } from "./Evaluator";
  * @returns {Object}
  *   The flattened components map.
  */
-export function flattenComponents(components: any, includeAll: boolean) {
+export function flattenComponents(components: Component[], includeAll: boolean) {
   const flattened: any = {};
   eachComponent(
     components,
@@ -102,7 +102,7 @@ export const MODEL_TYPES: Record<string, string[]> = {
   ],
 };
 
-export function getModelType(component: any) {
+export function getModelType(component: Component) {
   if (isComponentNestedDataType(component)) {
     if (isComponentModelType(component, 'dataObject')) {
       return 'dataObject';
@@ -135,30 +135,30 @@ export function getComponentPath(component: Component, path: string) {
   return (getModelType(component) === 'inherit') ? `${path}.${key}` : path;
 }
 
-export function isComponentModelType(component: any, modelType: string) {
+export function isComponentModelType(component: Component, modelType: string) {
   return component.modelType === modelType || MODEL_TYPES[modelType].includes(component.type);
 }
 
 export function isComponentNestedDataType(component: any) {
-  return component.tree || isComponentModelType(component, 'array') || 
+  return component.tree || isComponentModelType(component, 'array') ||
     isComponentModelType(component, 'dataObject') ||
-    isComponentModelType(component, 'object') || 
+    isComponentModelType(component, 'object') ||
     isComponentModelType(component, 'map');
 }
 
-export function componentPath(component: any, parentPath?: string) {
+export function componentPath(component: Component, parentPath?: string): string {
   parentPath = component.parentPath || parentPath;
   const key = getComponentKey(component);
   if (!key) {
     // If the component does not have a key, then just always return the parent path.
-    return parentPath;
+    return parentPath || '';
   }
 
   // If the component has a path property, then use it.
   if (component.path) {
     return component.path;
   }
-  
+
   return parentPath ? `${parentPath}.${key}` : key;
 }
 
@@ -270,7 +270,7 @@ export const eachComponentData = (
 
 export function getComponentKey(component: Component) {
   if (
-    component.type === 'checkbox' && 
+    component.type === 'checkbox' &&
     component.inputType === 'radio' &&
     (component as CheckboxComponent).name
   ) {

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -70,7 +70,7 @@ export function setActionStringProperty(context: LogicContext, action: LogicActi
 
 export function setActionProperty(context: LogicContext, action: LogicActionProperty): boolean {
     switch (action.property.type) {
-      case 'boolean': 
+      case 'boolean':
         return setActionBooleanProperty(context, action as LogicActionPropertyBoolean);
       case 'string':
         return setActionStringProperty(context, action as LogicActionPropertyString);
@@ -79,25 +79,24 @@ export function setActionProperty(context: LogicContext, action: LogicActionProp
 }
 
 export function setValueProperty(context: LogicContext, action: LogicActionValue) {
-    const { component, row, value } = context;
-    const oldValue = get(row, getComponentKey(component));
-    const newValue = evaluate({...context, value}, action.value, 'value', (evalContext: any) => {
+    const { component, data, value, path} = context;
+    const oldValue = get(data, path);
+    const newValue = evaluate(context, action.value, 'value', (evalContext: any) => {
         evalContext.value = clone(oldValue);
     });
     if (
-        !isEqual(oldValue, newValue) && 
+        !isEqual(oldValue, newValue) &&
         !(component.clearOnHide && conditionallyHidden(context as ProcessorContext<ConditionsScope>))
     ) {
-        context.value = newValue;
-        set(row, getComponentKey(component), newValue);
+        set(data, path, newValue);
         return true;
     }
     return false;
 }
 
 export function setMergeComponentSchema(context: LogicContext, action: LogicActionMergeComponentSchema) {
-    const { component, row } = context;
-    const oldValue = get(row, getComponentKey(component));
+    const { component, data, path } = context;
+    const oldValue = get(data, path);
     const schema = evaluate({...context, value: {}}, action.schemaDefinition, 'schema', (evalContext: any) => {
         evalContext.value = clone(oldValue);
     });


### PR DESCRIPTION
This PR makes a number of updates to fix server side validation in the Form.io Enterprise Server. Among other things, it

1. adds a "normalize" processor function to mimic the data normalization in the [renderer's updateValue](https://github.com/formio/formio.js/blob/15418d8ff0561f3ab42b7abd8ccd1556859245be/src/components/_classes/component/Component.js#L2700) method;
2. no longer mutates a separate `context.value` property, and instead uses a getter and a setter to derive from the `context.data` object; and
3. makes a number of other small changes to ensure compatibility with server side validation in the Enterprise Server.

