### PR TITLE
FIO-7938: Fixing issues where components within Array components (lik…

### DIFF
--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -153,12 +153,6 @@ export function componentPath(component: Component, parentPath?: string): string
     // If the component does not have a key, then just always return the parent path.
     return parentPath || '';
   }
-
-  // If the component has a path property, then use it.
-  if (component.path) {
-    return component.path;
-  }
-
   return parentPath ? `${parentPath}.${key}` : key;
 }
 


### PR DESCRIPTION
…e datagrid) would get the path of the first index assigned and would never update again.

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7938

## Description

When we are iterating over an array of data, the path changes per component. This code had a flaw where it would assign a path to the component, and then return that for the component path. The problem is that when the first row component would set (such as "customers[0].firstName") it would never re-establish the correct component path for the other indexes in the array causing some bugs with array based components.

## Breaking Changes / Backwards Compatibility

No breaking changes.

## Dependencies

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
