### PR TITLE
FIO-7884: Fixed an issue with nested form data where it would not set correctly.

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { process } from "processes/process";
+import { processSync, ProcessTargets } from "../index";
 const form1 = require('./fixtures/form1.json');
 const data1a = require('./fixtures/data1a.json');
 const subs = require('./fixtures/subs.json');
@@ -64,3 +64,257 @@ describe('Process Tests', () => {
     });
 });
 */
+
+describe('Process Tests', () => {
+    it('Should process nested form data correctly', async () => {
+        const submission = {
+            data: {
+                submit: true,
+                child: {
+                    data: {
+                        input: "4",
+                        output: 200,
+                    },
+                },
+            },
+            owner: "65df88d8a98df60a25008300",
+            access: [
+            ],
+            metadata: {
+                headers: {
+                    "accept-language": "en-US,en",
+                    "cache-control": "no-cache",
+                    connection: "keep-alive",
+                    origin: "http://localhost:3000",
+                    pragma: "no-cache",
+                    referer: "http://localhost:3000/",
+                    "sec-fetch-dest": "empty",
+                    "sec-fetch-mode": "cors",
+                    "sec-fetch-site": "same-origin",
+                    "sec-gpc": "1",
+                    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+                    accept: "application/json",
+                    "content-type": "application/json",
+                    "sec-ch-ua": "\"Chromium\";v=\"122\", \"Not(A:Brand\";v=\"24\", \"Brave\";v=\"122\"",
+                    "sec-ch-ua-mobile": "?0",
+                    "sec-ch-ua-platform": "\"macOS\"",
+                    host: "localhost:3000",
+                    "accept-encoding": "gzip, deflate, br",
+                    "content-length": "172",
+                },
+            },
+            form: "65e74c65ef4451c9ede341e3",
+        };
+        const form = {
+            title: "Parent Form",
+            name: "parentForm",
+            path: "parentform",
+            type: "form",
+            display: "form",
+            tags: [
+            ],
+            deleted: null,
+            access: [
+                {
+                    type: "create_own",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "create_all",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "read_own",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "read_all",
+                    roles: [
+                        {
+                        },
+                        {
+                        },
+                        {
+                        },
+                    ],
+                },
+                {
+                    type: "update_own",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "update_all",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "delete_own",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "delete_all",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "team_read",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "team_write",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "team_admin",
+                    roles: [
+                    ],
+                },
+            ],
+            submissionAccess: [
+                {
+                    type: "create_own",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "create_all",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "read_own",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "read_all",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "update_own",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "update_all",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "delete_own",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "delete_all",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "team_read",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "team_write",
+                    roles: [
+                    ],
+                },
+                {
+                    type: "team_admin",
+                    roles: [
+                    ],
+                },
+            ],
+            owner: {
+            },
+            components: [
+                {
+                    label: "Child",
+                    tableView: true,
+                    form: "65e74c2aef4451c9ede34105",
+                    useOriginalRevision: false,
+                    reference: false,
+                    key: "child",
+                    type: "form",
+                    input: true,
+                    components: [
+                        {
+                            label: "Input",
+                            applyMaskOn: "change",
+                            tableView: true,
+                            key: "input",
+                            type: "textfield",
+                            input: true,
+                        },
+                        {
+                            label: "Output",
+                            applyMaskOn: "change",
+                            disabled: true,
+                            tableView: true,
+                            calculateValue: "value = parseInt(data.input) * 5;",
+                            calculateServer: true,
+                            key: "output",
+                            type: "textfield",
+                            input: true,
+                        },
+                        {
+                            type: "button",
+                            label: "Submit",
+                            key: "submit",
+                            disableOnInvalid: true,
+                            input: true,
+                            tableView: false,
+                        },
+                    ],
+                },
+                {
+                    type: "button",
+                    label: "Submit",
+                    key: "submit",
+                    disableOnInvalid: true,
+                    input: true,
+                    tableView: false,
+                },
+            ],
+            settings: {
+            },
+            properties: {
+            },
+            project: {
+            },
+            controller: "",
+            revisions: "",
+            submissionRevisions: "",
+            _vid: 0,
+            created: "2024-03-05T16:46:29.859Z",
+            modified: "2024-03-05T18:50:08.638Z",
+            machineName: "tzcuqutdtlpgicr:parentForm",
+            __v: 1,
+            config: {
+                appUrl: "http://localhost:3000/tzcuqutdtlpgicr",
+            },
+        };
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: {},
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        expect(context.data.child.data.output).to.equal(20);
+    });
+});

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -11,7 +11,6 @@ import {
     isSimpleConditional,
     isJSONConditional
 } from 'utils/conditions';
-import { has } from 'lodash';
 
 const skipOnServer = (context: ConditionsContext): boolean => {
     const { component, config } = context;

--- a/src/process/normalize/index.ts
+++ b/src/process/normalize/index.ts
@@ -215,7 +215,8 @@ const normalizeTagsComponentValue = (component: TagsComponent, value: any) => {
 const normalizeMaskValue = (
     component: TextFieldComponent,
     defaultValues: DefaultValueScope['defaultValues'],
-    value: any
+    value: any,
+    path: string
 ) => {
     if (component.inputMasks && component.inputMasks.length > 0) {
         if (!value || typeof value !== 'object') {
@@ -225,7 +226,7 @@ const normalizeMaskValue = (
             }
         }
         if (!value.value) {
-            const defaultValue = defaultValues?.find((defaultValue) => defaultValue.path === component.path);
+            const defaultValue = defaultValues?.find((defaultValue) => defaultValue.path === path);
             value.value = Array.isArray(defaultValue) && defaultValue.length > 0 ? defaultValue[0] : defaultValue;
         }
     }
@@ -235,13 +236,14 @@ const normalizeMaskValue = (
 const normalizeTextFieldComponentValue = (
     component: TextFieldComponent,
     defaultValues: DefaultValueScope['defaultValues'],
-    value: any
+    value: any,
+    path: string
 ) => {
     if (component.allowMultipleMasks && component.inputMasks && component.inputMasks.length > 0) {
         if (Array.isArray(value)) {
-            return value.map((val) => normalizeMaskValue(component, defaultValues, val));
+            return value.map((val) => normalizeMaskValue(component, defaultValues, val, path));
         } else {
-            return normalizeMaskValue(component, defaultValues, value);
+            return normalizeMaskValue(component, defaultValues, value, path);
         }
     }
     return value;
@@ -272,7 +274,7 @@ export const normalizeProcessSync: ProcessorFnSync<NormalizeScope> = (context) =
     } else if (isTagsComponent(component)) {
         set(data, path, normalizeTagsComponentValue(component, value));
     } else if (isTextFieldComponent(component)) {
-       set(data, path, normalizeTextFieldComponentValue(component, defaultValues, value));
+       set(data, path, normalizeTextFieldComponentValue(component, defaultValues, value, path));
     }
 
     // Next perform component-type-agnostic transformations (i.e. super())

--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -14,12 +14,13 @@ import { normalizeProcessInfo } from "./normalize";
 
 export async function process<ProcessScope>(context: ProcessContext<ProcessScope>): Promise<ProcessScope> {
     const { instances, components, data, scope, flat, processors } = context;
-    await eachComponentDataAsync(components, data, async (component, _, row, path, components, index) => {
+    await eachComponentDataAsync(components, data, async (component, compData, row, path, components, index) => {
         // Skip processing if row is null or undefined
         if (!row) {
             return;
         }
         await processOne<ProcessScope>({...context, ...{
+            data: compData,
             component,
             components,
             path,
@@ -46,12 +47,13 @@ export async function process<ProcessScope>(context: ProcessContext<ProcessScope
 
 export function processSync<ProcessScope>(context: ProcessContext<ProcessScope>): ProcessScope {
     const { instances, components, data, scope, flat, processors } = context;
-    eachComponentData(components, data, (component, _, row, path, components, index) => {
+    eachComponentData(components, data, (component, compData, row, path, components, index) => {
         // Skip processing if row is null or undefined
         if (!row) {
             return;
         }
         processOneSync<ProcessScope>({...context,
+            data: compData,
             component,
             components,
             path,

--- a/src/process/processOne.ts
+++ b/src/process/processOne.ts
@@ -44,12 +44,9 @@ export function processOneSync<ProcessorScope>(context: ProcessorsContext<Proces
             }
         });
     }
-    // Check if the component is in a nested form
-    let parent: any = component?.parent;
-    while (parent?.type !== "form" && parent !== undefined && parent !== null) {
-        parent = parent?.parent;
+    if (!context.row) {
+        return;
     }
-    
     context.processor = ProcessorType.Custom;
     processors.forEach((processor) => {
         if (processor?.processSync) {

--- a/src/utils/conditions.ts
+++ b/src/utils/conditions.ts
@@ -18,10 +18,10 @@ export const isSimpleConditional = (conditional: any): conditional is SimpleCond
 }
 
 export function conditionallyHidden(context: ConditionsContext) {
-    const { scope, component } = context;
-    if (scope.conditionals && component.path) {
+    const { scope, component, path } = context;
+    if (scope.conditionals && path) {
         const hidden = find(scope.conditionals, (conditional) => {
-            return conditional.path === component.path;
+            return conditional.path === path;
         });
         return hidden?.conditionallyHidden;
     }

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -153,12 +153,6 @@ export function componentPath(component: Component, parentPath?: string): string
     // If the component does not have a key, then just always return the parent path.
     return parentPath || '';
   }
-
-  // If the component has a path property, then use it.
-  if (component.path) {
-    return component.path;
-  }
-
   return parentPath ? `${parentPath}.${key}` : key;
 }
 
@@ -348,11 +342,6 @@ export function eachComponent(
     }
     const info = componentInfo(component);
     let noRecurse = false;
-    Object.defineProperty(component, 'path', {
-      enumerable: false,
-      writable: true,
-      value: componentPath(component, path)
-    });
     // Keep track of parent references.
     if (parent) {
       // Ensure we don't create infinite JSON structures.
@@ -368,7 +357,7 @@ export function eachComponent(
       delete component.parent.rows;
     }
     if (includeAll || component.tree || !info.iterable) {
-      noRecurse = fn(component, component.path, components, parent);
+      noRecurse = fn(component, componentPath(component, path), components, parent);
     }
 
     if (!noRecurse) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7884

## Description

When calling eachComponentData, and when making a call within a nested form, we need to reset the "path" and child "data" object so that the child components "believe" that they are at the root level. The reason for this, is when you are building a nested form, you would never build that nested form with the knowledge that you would be embedding that form within a parent form. All of your logic and custom evals would be written as if the nested form context is at the root. Because of this, our eachComponentData method needs to "trick" the nested form to use the correct context when making evaluations.

## Breaking Changes / Backwards Compatibility

None that I am aware of.

## How has this PR been tested?

I wrote an automated test that would fail if the contexts were not what they are supposed to be.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
