### PR TITLE
FIO-7884: Fixed issues with processing data within nested form data structures.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
-## [Unreleased: 2.0.0-rc.14]
+## 2.0.0-rc.14
+### Changed
  - FIO-7884: Fixed an issue with nested form data where it would not set correctly
  - FIO-7938: Fixing issues where components within Array components (like datagrid) would get the path of the first index assigned and would never update again
  - FIO-7958: add asynchronous rule set

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.0.0-rc.13",
+  "version": "2.0.0-rc.15",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { processSync, ProcessTargets } from "../index";
+const assert = require('assert');
 const form1 = require('./fixtures/form1.json');
 const data1a = require('./fixtures/data1a.json');
 const subs = require('./fixtures/subs.json');
@@ -317,4 +318,1437 @@ describe('Process Tests', () => {
         processSync(context);
         expect(context.data.child.data.output).to.equal(20);
     });
+
+    it('Should process nested data correctly.', async () => {
+        const form = {
+            _id: {
+            },
+            title: "parent",
+            name: "parent",
+            path: "parent",
+            type: "form",
+            display: "form",
+            tags: [
+            ],
+            deleted: null,
+            access: [
+                {
+                    type: "read_all",
+                    roles: [
+                        {
+                        },
+                        {
+                        },
+                        {
+                        },
+                    ],
+                },
+            ],
+            submissionAccess: [
+            ],
+            owner: {
+            },
+            components: [
+                {
+                    type: "checkbox",
+                    label: "Show A",
+                    key: "showA",
+                    input: true,
+                },
+                {
+                    type: "checkbox",
+                    label: "Show B",
+                    key: "showB",
+                    input: true,
+                },
+                {
+                    type: "checkbox",
+                    label: "Show C",
+                    key: "showC",
+                    input: true,
+                },
+                {
+                    type: "form",
+                    form: "65e8786fc5dacf667eef12d2",
+                    label: "Child A",
+                    key: "childA",
+                    input: true,
+                    conditional: {
+                        show: true,
+                        when: "showA",
+                        eq: true,
+                    },
+                    components: [
+                        {
+                            type: "textfield",
+                            label: "A",
+                            key: "a",
+                            validate: {
+                                required: true,
+                            },
+                            input: true,
+                        },
+                        {
+                            type: "textfield",
+                            label: "B",
+                            key: "b",
+                            input: true,
+                        },
+                    ],
+                },
+                {
+                    type: "form",
+                    form: "65e8786fc5dacf667eef12e0",
+                    label: "Child B",
+                    key: "childB",
+                    input: true,
+                    conditional: {
+                        show: true,
+                        when: "showB",
+                        eq: true,
+                    },
+                    components: [
+                        {
+                            type: "textfield",
+                            label: "C",
+                            key: "c",
+                            input: true,
+                            validate: {
+                                required: true,
+                            },
+                        },
+                        {
+                            type: "textfield",
+                            label: "D",
+                            key: "d",
+                            input: true,
+                        },
+                    ],
+                },
+                {
+                    type: "form",
+                    form: "65e8786fc5dacf667eef12ee",
+                    label: "Child C",
+                    key: "childC",
+                    conditional: {
+                        show: true,
+                        when: "showC",
+                        eq: true,
+                    },
+                    input: true,
+                    components: [
+                        {
+                            type: "textfield",
+                            label: "E",
+                            key: "e",
+                            input: true,
+                            validate: {
+                                required: true,
+                            },
+                        },
+                        {
+                            type: "textfield",
+                            label: "F",
+                            key: "f",
+                            input: true,
+                        },
+                    ],
+                },
+            ],
+            created: "2024-03-06T14:06:39.724Z",
+            modified: "2024-03-06T14:06:39.726Z",
+            machineName: "parent",
+            __v: 0,
+        };
+        const submission = {
+            data: {
+                showA: true,
+                showB: true,
+                showC: true,
+                childA: {
+                    data: {
+                        a: "One",
+                        b: "Two",
+                    },
+                },
+                childB: {
+                    data: {
+                        c: "Three",
+                        d: "Four",
+                    },
+                },
+                childC: {
+                    data: {
+                        e: "Five",
+                        f: "Six",
+                    },
+                },
+            },
+            owner: "65e87843c5dacf667eeeecc1",
+            access: [
+            ],
+            metadata: {
+                headers: {
+                    host: "127.0.0.1:64851",
+                    "accept-encoding": "gzip, deflate",
+                    "content-type": "application/json",
+                    "content-length": "173",
+                    connection: "close",
+                },
+            },
+            form: "65e8786fc5dacf667eef12fc",
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.submission,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        submission.data = context.data;
+        context.processors = ProcessTargets.evaluator;
+        processSync(context);
+        assert.equal(context.scope.errors.length, 0);
+        assert.equal(context.data.showA, true);
+        assert.equal(context.data.showB, true);
+        assert.equal(context.data.showC, true);
+        assert.deepEqual(context.data.childA.data, {
+            a: 'One',
+            b: 'Two'
+        });
+        assert.deepEqual(context.data.childB.data, {
+            c: 'Three',
+            d: 'Four'
+        });
+        assert.deepEqual(context.data.childC.data, {
+            e: 'Five',
+            f: 'Six'
+        });
+    });
+
+    it('Should allow the submission to go through if the subform is conditionally hidden', async () => {
+        const form = {
+            _id: {
+            },
+            title: "parent",
+            name: "parent",
+            path: "parent",
+            type: "form",
+            display: "form",
+            tags: [
+            ],
+            deleted: null,
+            access: [
+                {
+                    type: "read_all",
+                    roles: [
+                        {
+                        },
+                        {
+                        },
+                        {
+                        },
+                    ],
+                },
+            ],
+            submissionAccess: [
+            ],
+            owner: {
+            },
+            components: [
+                {
+                    type: "checkbox",
+                    label: "Show A",
+                    key: "showA",
+                    input: true,
+                },
+                {
+                    type: "checkbox",
+                    label: "Show B",
+                    key: "showB",
+                    input: true,
+                },
+                {
+                    type: "checkbox",
+                    label: "Show C",
+                    key: "showC",
+                    input: true,
+                },
+                {
+                    type: "form",
+                    form: "65e8786fc5dacf667eef12d2",
+                    label: "Child A",
+                    key: "childA",
+                    input: true,
+                    conditional: {
+                        show: true,
+                        when: "showA",
+                        eq: true,
+                    },
+                    components: [
+                        {
+                            type: "textfield",
+                            label: "A",
+                            key: "a",
+                            validate: {
+                                required: true,
+                            },
+                            input: true,
+                        },
+                        {
+                            type: "textfield",
+                            label: "B",
+                            key: "b",
+                            input: true,
+                        },
+                    ],
+                },
+                {
+                    type: "form",
+                    form: "65e8786fc5dacf667eef12e0",
+                    label: "Child B",
+                    key: "childB",
+                    input: true,
+                    conditional: {
+                        show: true,
+                        when: "showB",
+                        eq: true,
+                    },
+                    components: [
+                        {
+                            type: "textfield",
+                            label: "C",
+                            key: "c",
+                            input: true,
+                            validate: {
+                                required: true,
+                            },
+                        },
+                        {
+                            type: "textfield",
+                            label: "D",
+                            key: "d",
+                            input: true,
+                        },
+                    ],
+                },
+                {
+                    type: "form",
+                    form: "65e8786fc5dacf667eef12ee",
+                    label: "Child C",
+                    key: "childC",
+                    conditional: {
+                        show: true,
+                        when: "showC",
+                        eq: true,
+                    },
+                    input: true,
+                    components: [
+                        {
+                            type: "textfield",
+                            label: "E",
+                            key: "e",
+                            input: true,
+                            validate: {
+                                required: true,
+                            },
+                        },
+                        {
+                            type: "textfield",
+                            label: "F",
+                            key: "f",
+                            input: true,
+                        },
+                    ],
+                },
+            ],
+            created: "2024-03-06T14:06:39.724Z",
+            modified: "2024-03-06T14:06:39.726Z",
+            machineName: "parent",
+            __v: 0,
+        };
+        const submission = {
+            data: {
+                showA: false,
+                showB: true,
+                showC: true,
+                childB: {
+                    data: {
+                        c: 'Three',
+                        d: 'Four'
+                    }
+                },
+                childC: {
+                    data: {
+                        e: 'Five',
+                        f: 'Six'
+                    }
+                }
+            },
+            owner: "65e87843c5dacf667eeeecc1",
+            access: [
+            ],
+            metadata: {
+                headers: {
+                    host: "127.0.0.1:64851",
+                    "accept-encoding": "gzip, deflate",
+                    "content-type": "application/json",
+                    "content-length": "173",
+                    connection: "close",
+                },
+            },
+            form: "65e8786fc5dacf667eef12fc",
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.submission,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        submission.data = context.data;
+        context.processors = ProcessTargets.evaluator;
+        processSync(context);
+        assert.equal(context.scope.errors.length, 0);
+        assert.equal(context.data.showA, false);
+        assert.equal(context.data.showB, true);
+        assert.equal(context.data.showC, true);
+        assert(!context.data.hasOwnProperty('childA'), 'The childA form should not be present.');
+        assert.deepEqual(context.data.childB.data, {
+            c: 'Three',
+            d: 'Four'
+        });
+        assert.deepEqual(context.data.childC.data, {
+            e: 'Five',
+            f: 'Six'
+        });
+    });
+
+    it('Should process data within a fieldset properly.', async () => {
+        const submission = {
+            data: {
+                firstName: 'Joe',
+                lastName: 'Smith'
+            }
+        };
+        const form = {
+            components: [
+                {
+                    type: 'fieldset',
+                    key: 'name',
+                    input: false,
+                    components: [
+                        {
+                            type: 'textfield',
+                            key: 'firstName',
+                            input: true
+                        },
+                        {
+                            type: 'textfield',
+                            key: 'lastName',
+                            input: true
+                        }
+                    ]
+                }
+            ]
+        };
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.submission,
+            scope: {},
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        expect(context.data.firstName).to.equal('Joe');
+        expect(context.data.lastName).to.equal('Smith');
+    });
+
+    it('Requires a conditionally visible field', async () => {
+        const form = {
+            components: [
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "radio",
+                    "label": "Selector",
+                    "key": "selector",
+                    "values": [
+                        {
+                            "value": "one",
+                            "label": "One"
+                        },
+                        {
+                            "value": "two",
+                            "label": "Two"
+                        }
+                    ],
+                    "defaultValue": "",
+                    "protected": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "type": "radio",
+                    "conditional": {
+                        "show": "",
+                        "when": null,
+                        "eq": ""
+                    }
+                },
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "text",
+                    "inputMask": "",
+                    "label": "Required Field",
+                    "key": "requiredField",
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": "",
+                    "protected": false,
+                    "unique": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "minLength": "",
+                        "maxLength": "",
+                        "pattern": "",
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "conditional": {
+                        "show": "true",
+                        "when": "selector",
+                        "eq": "two"
+                    },
+                    "type": "textfield"
+                }
+            ]
+        }
+
+        const submission = { data: { selector: 'two' } }
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        assert.equal(context.scope.errors.length, 1);
+        assert.equal(context.scope.errors[0].errorKeyOrMessage, 'required');
+        assert.equal(context.scope.errors[0].context.path, 'requiredField');
+    });
+
+    it('Doesn\'t require a conditionally hidden field', async () => {
+        const form = {
+            components: [
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "radio",
+                    "label": "Selector",
+                    "key": "selector",
+                    "values": [
+                        {
+                            "value": "one",
+                            "label": "One"
+                        },
+                        {
+                            "value": "two",
+                            "label": "Two"
+                        }
+                    ],
+                    "defaultValue": "",
+                    "protected": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "type": "radio",
+                    "conditional": {
+                        "show": "",
+                        "when": null,
+                        "eq": ""
+                    }
+                },
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "text",
+                    "inputMask": "",
+                    "label": "Required Field",
+                    "key": "requiredField",
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": "",
+                    "protected": false,
+                    "unique": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "minLength": "",
+                        "maxLength": "",
+                        "pattern": "",
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "conditional": {
+                        "show": "true",
+                        "when": "selector",
+                        "eq": "two"
+                    },
+                    "type": "textfield"
+                }
+            ]
+        };
+
+        const submission = {
+            data: {
+                selector: 'one'
+            }
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        assert.equal(context.scope.errors.length, 0);
+    });
+
+    it('Allows a conditionally required field', async () => {
+        const form = {
+            components: [
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "radio",
+                    "label": "Selector",
+                    "key": "selector",
+                    "values": [
+                        {
+                            "value": "one",
+                            "label": "One"
+                        },
+                        {
+                            "value": "two",
+                            "label": "Two"
+                        }
+                    ],
+                    "defaultValue": "",
+                    "protected": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "type": "radio",
+                    "conditional": {
+                        "show": "",
+                        "when": null,
+                        "eq": ""
+                    }
+                },
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "text",
+                    "inputMask": "",
+                    "label": "Required Field",
+                    "key": "requiredField",
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": "",
+                    "protected": false,
+                    "unique": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "minLength": "",
+                        "maxLength": "",
+                        "pattern": "",
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "conditional": {
+                        "show": "true",
+                        "when": "selector",
+                        "eq": "two"
+                    },
+                    "type": "textfield"
+                }
+            ]
+        };
+
+        const submission = {
+            data: {
+                selector: 'two',
+                requiredField: 'Has a value'
+            }
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        assert.equal(context.scope.errors.length, 0);
+    });
+
+    it('Ignores conditionally hidden fields', async () => {
+        const form = {
+            components: [
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "radio",
+                    "label": "Selector",
+                    "key": "selector",
+                    "values": [
+                        {
+                            "value": "one",
+                            "label": "One"
+                        },
+                        {
+                            "value": "two",
+                            "label": "Two"
+                        }
+                    ],
+                    "defaultValue": "",
+                    "protected": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "type": "radio",
+                    "conditional": {
+                        "show": "",
+                        "when": null,
+                        "eq": ""
+                    }
+                },
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "text",
+                    "inputMask": "",
+                    "label": "Required Field",
+                    "key": "requiredField",
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": "",
+                    "protected": false,
+                    "unique": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "minLength": "",
+                        "maxLength": "",
+                        "pattern": "",
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "conditional": {
+                        "show": "true",
+                        "when": "selector",
+                        "eq": "two"
+                    },
+                    "type": "textfield"
+                }
+            ]
+        };
+
+        const submission = {
+            data: {
+                selector: 'one',
+                requiredField: 'Has a value'
+            }
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        assert.deepEqual(context.data, { selector: 'one' });
+        assert.equal(context.scope.errors.length, 0);
+    });
+
+    it('Requires a conditionally visible field in a panel', async () => {
+        const form = {
+            components: [
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "radio",
+                    "label": "Selector",
+                    "key": "selector",
+                    "values": [
+                        {
+                            "value": "one",
+                            "label": "One"
+                        },
+                        {
+                            "value": "two",
+                            "label": "Two"
+                        }
+                    ],
+                    "defaultValue": "",
+                    "protected": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "type": "radio",
+                    "conditional": {
+                        "show": "",
+                        "when": null,
+                        "eq": ""
+                    }
+                },
+                {
+                    "input": false,
+                    "title": "Panel",
+                    "theme": "default",
+                    "components": [
+                        {
+                            "input": true,
+                            "tableView": true,
+                            "inputType": "text",
+                            "inputMask": "",
+                            "label": "Required Field",
+                            "key": "requiredField",
+                            "placeholder": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": "",
+                            "protected": false,
+                            "unique": false,
+                            "persistent": true,
+                            "validate": {
+                                "required": true,
+                                "minLength": "",
+                                "maxLength": "",
+                                "pattern": "",
+                                "custom": "",
+                                "customPrivate": false
+                            },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "type": "textfield"
+                        }
+                    ],
+                    "type": "panel",
+                    "key": "panel",
+                    "conditional": {
+                        "show": "true",
+                        "when": "selector",
+                        "eq": "two"
+                    }
+                }
+            ]
+        };
+
+        const submission = {
+            data: {
+                selector: 'two'
+            }
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        assert.equal(context.scope.errors.length, 1);
+        assert.equal(context.scope.errors[0].errorKeyOrMessage, 'required');
+        assert.equal(context.scope.errors[0].context.path, 'requiredField');
+    });
+
+    it('Doesn\'t require a conditionally hidden field in a panel', async () => {
+        const form = {
+            components: [
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "radio",
+                    "label": "Selector",
+                    "key": "selector",
+                    "values": [
+                        {
+                            "value": "one",
+                            "label": "One"
+                        },
+                        {
+                            "value": "two",
+                            "label": "Two"
+                        }
+                    ],
+                    "defaultValue": "",
+                    "protected": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "type": "radio",
+                    "conditional": {
+                        "show": "",
+                        "when": null,
+                        "eq": ""
+                    }
+                },
+                {
+                    "input": false,
+                    "title": "Panel",
+                    "theme": "default",
+                    "components": [
+                        {
+                            "input": true,
+                            "tableView": true,
+                            "inputType": "text",
+                            "inputMask": "",
+                            "label": "Required Field",
+                            "key": "requiredField",
+                            "placeholder": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": "",
+                            "protected": false,
+                            "unique": false,
+                            "persistent": true,
+                            "validate": {
+                                "required": true,
+                                "minLength": "",
+                                "maxLength": "",
+                                "pattern": "",
+                                "custom": "",
+                                "customPrivate": false
+                            },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "type": "textfield"
+                        }
+                    ],
+                    "type": "panel",
+                    "key": "panel",
+                    "conditional": {
+                        "show": "true",
+                        "when": "selector",
+                        "eq": "two"
+                    }
+                }
+            ]
+        };
+
+        const submission = {
+            data: {
+                selector: 'one'
+            }
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        assert.equal(context.scope.errors.length, 0);
+
+    });
+
+    it('Allows a conditionally required field in a panel', async () => {
+        const form = {
+            components: [
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "radio",
+                    "label": "Selector",
+                    "key": "selector",
+                    "values": [
+                        {
+                            "value": "one",
+                            "label": "One"
+                        },
+                        {
+                            "value": "two",
+                            "label": "Two"
+                        }
+                    ],
+                    "defaultValue": "",
+                    "protected": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "type": "radio",
+                    "conditional": {
+                        "show": "",
+                        "when": null,
+                        "eq": ""
+                    }
+                },
+                {
+                    "input": false,
+                    "title": "Panel",
+                    "theme": "default",
+                    "components": [
+                        {
+                            "input": true,
+                            "tableView": true,
+                            "inputType": "text",
+                            "inputMask": "",
+                            "label": "Required Field",
+                            "key": "requiredField",
+                            "placeholder": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": "",
+                            "protected": false,
+                            "unique": false,
+                            "persistent": true,
+                            "validate": {
+                                "required": true,
+                                "minLength": "",
+                                "maxLength": "",
+                                "pattern": "",
+                                "custom": "",
+                                "customPrivate": false
+                            },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "type": "textfield"
+                        }
+                    ],
+                    "type": "panel",
+                    "key": "panel",
+                    "conditional": {
+                        "show": "true",
+                        "when": "selector",
+                        "eq": "two"
+                    }
+                }
+            ]
+        };
+
+        const submission = {
+            data: {
+                selector: 'two',
+                requiredField: 'Has a value'
+            }
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        assert.equal(context.scope.errors.length, 0);
+
+    });
+
+    it('Ignores conditionally hidden fields in a panel', async () => {
+        const form = {
+            components: [
+                {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "radio",
+                    "label": "Selector",
+                    "key": "selector",
+                    "values": [
+                        {
+                            "value": "one",
+                            "label": "One"
+                        },
+                        {
+                            "value": "two",
+                            "label": "Two"
+                        }
+                    ],
+                    "defaultValue": "",
+                    "protected": false,
+                    "persistent": true,
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "type": "radio",
+                    "conditional": {
+                        "show": "",
+                        "when": null,
+                        "eq": ""
+                    }
+                },
+                {
+                    "input": false,
+                    "title": "Panel",
+                    "theme": "default",
+                    "components": [
+                        {
+                            "input": true,
+                            "tableView": true,
+                            "inputType": "text",
+                            "inputMask": "",
+                            "label": "Required Field",
+                            "key": "requiredField",
+                            "placeholder": "",
+                            "prefix": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": "",
+                            "protected": false,
+                            "unique": false,
+                            "persistent": true,
+                            "validate": {
+                                "required": true,
+                                "minLength": "",
+                                "maxLength": "",
+                                "pattern": "",
+                                "custom": "",
+                                "customPrivate": false
+                            },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "type": "textfield"
+                        }
+                    ],
+                    "type": "panel",
+                    "key": "panel",
+                    "conditional": {
+                        "show": "true",
+                        "when": "selector",
+                        "eq": "two"
+                    }
+                }
+            ]
+        };
+
+        const submission = {
+            data: {
+                selector: 'one',
+                requiredField: 'Has a value'
+            }
+        };
+
+        const errors: any = [];
+        const context = {
+            form,
+            submission,
+            data: submission.data,
+            components: form.components,
+            processors: ProcessTargets.evaluator,
+            scope: { errors },
+            config: {
+                server: true
+            }
+        };
+        processSync(context);
+        assert.deepEqual(context.data, { selector: 'one' });
+        assert.equal(context.scope.errors.length, 0);
+    });
+    /*
+          it('Should not clearOnHide when set to false', async () => {
+            var components = [
+              {
+                "input": true,
+                "tableView": true,
+                "inputType": "radio",
+                "label": "Selector",
+                "key": "selector",
+                "values": [
+                  {
+                    "value": "one",
+                    "label": "One"
+                  },
+                  {
+                    "value": "two",
+                    "label": "Two"
+                  }
+                ],
+                "defaultValue": "",
+                "protected": false,
+                "persistent": true,
+                "validate": {
+                  "required": false,
+                  "custom": "",
+                  "customPrivate": false
+                },
+                "type": "radio",
+                "conditional": {
+                  "show": "",
+                  "when": null,
+                  "eq": ""
+                }
+              },
+              {
+                "input": false,
+                "title": "Panel",
+                "theme": "default",
+                "components": [
+                  {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "text",
+                    "inputMask": "",
+                    "label": "No Clear Field",
+                    "key": "noClear",
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": "",
+                    "protected": false,
+                    "unique": false,
+                    "persistent": true,
+                    "clearOnHide": false,
+                    "validate": {
+                      "required": false,
+                      "minLength": "",
+                      "maxLength": "",
+                      "pattern": "",
+                      "custom": "",
+                      "customPrivate": false
+                    },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "type": "textfield"
+                  }
+                ],
+                "type": "panel",
+                "key": "panel",
+                "conditional": {
+                  "show": "true",
+                  "when": "selector",
+                  "eq": "two"
+                }
+              }
+            ];
+    
+            helper
+              .form('test', components)
+              .submission({
+                selector: 'one',
+                noClear: 'testing'
+              })
+              .execute(function(err) {
+                if (err) {
+                  return done(err);
+                }
+    
+                var submission = helper.getLastSubmission();
+                assert.deepEqual({selector: 'one', noClear: 'testing'}, submission.data);
+                done();
+              });
+          });
+    
+          it('Should clearOnHide when set to true', async () => {
+            var components = [
+              {
+                "input": true,
+                "tableView": true,
+                "inputType": "radio",
+                "label": "Selector",
+                "key": "selector",
+                "values": [
+                  {
+                    "value": "one",
+                    "label": "One"
+                  },
+                  {
+                    "value": "two",
+                    "label": "Two"
+                  }
+                ],
+                "defaultValue": "",
+                "protected": false,
+                "persistent": true,
+                "validate": {
+                  "required": false,
+                  "custom": "",
+                  "customPrivate": false
+                },
+                "type": "radio",
+                "conditional": {
+                  "show": "",
+                  "when": null,
+                  "eq": ""
+                }
+              },
+              {
+                "input": false,
+                "title": "Panel",
+                "theme": "default",
+                "components": [
+                  {
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "text",
+                    "inputMask": "",
+                    "label": "Clear Me",
+                    "key": "clearMe",
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": "",
+                    "protected": false,
+                    "unique": false,
+                    "persistent": true,
+                    "clearOnHide": true,
+                    "validate": {
+                      "required": false,
+                      "minLength": "",
+                      "maxLength": "",
+                      "pattern": "",
+                      "custom": "",
+                      "customPrivate": false
+                    },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "type": "textfield"
+                  }
+                ],
+                "type": "panel",
+                "key": "panel",
+                "conditional": {
+                  "show": "true",
+                  "when": "selector",
+                  "eq": "two"
+                }
+              }
+            ];
+    
+            helper
+              .form('test', components)
+              .submission({
+                selector: 'one',
+                clearMe: 'Clear Me!!!!'
+              })
+              .execute(function(err) {
+                if (err) {
+                  return done(err);
+                }
+    
+                var submission = helper.getLastSubmission();
+                assert.deepEqual({selector: 'one'}, submission.data);
+                done();
+              });
+          });
+    */
 });

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -2,25 +2,27 @@ import { FilterContext, FilterScope, ProcessorFn, ProcessorFnSync, ProcessorInfo
 import set from 'lodash/set';
 import { Utils } from "utils";
 import { get, isObject } from "lodash";
+import { getComponentAbsolutePath } from "utils/formUtil";
 export const filterProcessSync: ProcessorFnSync<FilterScope> = (context: FilterContext) => {
-    const { scope, path, component, data } = context;
+    const { scope, component } = context;
     let { value } = context;
+    const absolutePath = getComponentAbsolutePath(component);
     if (!scope.filter) scope.filter = {};
     if (value !== undefined) {
         const modelType = Utils.getModelType(component);
         switch (modelType) {
             case 'dataObject':
-                scope.filter[path] = {data: {}};
+                scope.filter[absolutePath] = {data: {}};
                 break;
             case 'array':
                 break;
             case 'object':
                 if (component.type !== 'container') {
-                    scope.filter[path] = true;
+                    scope.filter[absolutePath] = true;
                 }
                 break;
             default:
-                scope.filter[path] = true;
+                scope.filter[absolutePath] = true;
                 break;
         }
     }
@@ -31,11 +33,11 @@ export const filterProcess: ProcessorFn<FilterScope> = async (context: FilterCon
 };
 
 export const filterPostProcess: ProcessorFnSync<FilterScope> = (context: FilterContext) => {
-    const { scope, data } = context;
+    const { scope, submission } = context;
     const filtered = {};
     for (const path in scope.filter) {
         if (scope.filter[path]) {
-            let value = get(data, path);
+            let value = get(submission?.data, path);
             if (isObject(value) && isObject(scope.filter[path])) {
                 value = {...value, ...scope.filter[path]}
             }

--- a/src/process/validation/index.ts
+++ b/src/process/validation/index.ts
@@ -4,7 +4,7 @@ import find from "lodash/find";
 import get from "lodash/get";
 import set from "lodash/set";
 import pick from "lodash/pick";
-import { getComponentPath } from "utils/formUtil";
+import { getComponentAbsolutePath, getComponentPath } from "utils/formUtil";
 import { getErrorMessage } from "utils/error";
 import { FieldError } from "error";
 import { ConditionallyHidden, isConditionallyHidden, isCustomConditionallyHidden, isSimpleConditionallyHidden } from "processes/conditions";
@@ -147,14 +147,18 @@ export function shouldValidateServer(context: ValidationContext): boolean {
 }
 
 function handleError(error: FieldError | null, context: ValidationContext) {
-    const { path, scope } = context;
+    const { scope, component } = context;
+    const absolutePath = getComponentAbsolutePath(component);
     if (error) {
         const cleanedError = cleanupValidationError(error);
-        if (!find(scope.errors, { errorKeyOrMessage: cleanedError.errorKeyOrMessage, context: {path} })) {
+        cleanedError.context.path = absolutePath;
+        if (!find(scope.errors, { errorKeyOrMessage: cleanedError.errorKeyOrMessage, context: {
+            path: absolutePath
+        }})) {
             if (!scope.validated) scope.validated = [];
             if (!scope.errors) scope.errors = [];
             scope.errors.push(cleanedError);
-            scope.validated.push({ path, error: cleanedError });
+            scope.validated.push({ path: absolutePath, error: cleanedError });
         }
     }
 }

--- a/src/types/BaseComponent.ts
+++ b/src/types/BaseComponent.ts
@@ -2,7 +2,7 @@ import { RulesLogic } from "json-logic-js";
 import { AdvancedLogic } from "./AdvancedLogic";
 
 export type JSONConditional = { json: RulesLogic; };
-export type LegacyConditional = { show: boolean | null; when: string | null; eq: string };
+export type LegacyConditional = { show: boolean | string | null; when: string | null; eq: boolean | string };
 export type SimpleConditionalConditions = { component: string; operator: string; value: any}[];
 export type SimpleConditional = { show: boolean | null; conjunction: string; conditions: SimpleConditionalConditions};
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7884

## Description

When calling eachComponentData, and when making a call within a nested form, we need to reset the "path" and child "data" object so that the child components "believe" that they are at the root level. The reason for this, is when you are building a nested form, you would never build that nested form with the knowledge that you would be embedding that form within a parent form. All of your logic and custom evals would be written as if the nested form context is at the root. Because of this, our eachComponentData method needs to "trick" the nested form to use the correct context when making evaluations.

## Breaking Changes / Backwards Compatibility

None that I am aware of.

## How has this PR been tested?

I wrote an automated test that would fail if the contexts were not what they are supposed to be.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
