### PR TITLE
FIO-7964: add resource-based select component validation

### DIFF
--- a/src/process/validation/rules/databaseRules.ts
+++ b/src/process/validation/rules/databaseRules.ts
@@ -1,9 +1,11 @@
 import { ValidationRuleInfo } from "types";
 import { validateUniqueInfo } from "./validateUnique";
 import { validateCaptchaInfo } from "./validateCaptcha";
+import { validateResourceSelectValueInfo } from "./validateResourceSelectValue";
 
 // These are the validations that require a database connection.
 export const databaseRules: ValidationRuleInfo[] = [
     validateUniqueInfo,
-    validateCaptchaInfo
+    validateCaptchaInfo,
+    validateResourceSelectValueInfo
 ];

--- a/src/process/validation/rules/validateResourceSelectValue.ts
+++ b/src/process/validation/rules/validateResourceSelectValue.ts
@@ -1,0 +1,89 @@
+import { FieldError, ValidatorError } from 'error';
+import { SelectComponent, RuleFn, ValidationContext } from 'types';
+import { Evaluator } from 'utils';
+import { isEmptyObject, toBoolean } from '../util';
+import { getErrorMessage } from 'utils/error';
+import { ProcessorInfo } from 'types/process/ProcessorInfo';
+
+const isValidatableSelectComponent = (component: any): component is SelectComponent => {
+    return (
+        component &&
+        component.type === 'select' &&
+        toBoolean(component.dataSrc === 'resource') &&
+        toBoolean(component.validate?.select)
+    );
+};
+
+export const generateUrl = (baseUrl: URL, component: SelectComponent, value: any) => {
+    const url = baseUrl;
+    const query = url.searchParams;
+    if (component.searchField) {
+        let searchValue = value;
+        if (component.valueProperty) {
+            searchValue = value[component.valueProperty];
+        } else {
+            searchValue = value;
+        }
+        query.set(component.searchField, typeof searchValue === 'string' ? searchValue : JSON.stringify(searchValue))
+    }
+    if (component.selectFields) {
+        query.set('select', component.selectFields);
+    }
+    if (component.sort) {
+        query.set('sort', component.sort);
+    }
+    if (component.filter) {
+        const filterQueryStrings = new URLSearchParams(component.filter);
+        filterQueryStrings.forEach((value, key) => query.set(key, value));
+    }
+    return url;
+};
+
+export const shouldValidate = (context: ValidationContext) => {
+    const { component, value, data, config } = context;
+    // Only run this validation if server-side
+    if (!config?.server) {
+        return false;
+    }
+    if (!isValidatableSelectComponent(component)) {
+        return false;
+    }
+    if (
+        !value ||
+        isEmptyObject(value) ||
+        (Array.isArray(value) && (value as Array<Record<string, any>>).length === 0)
+    ) {
+        return false;
+    }
+
+    // If given an invalid configuration, do not validate the remote value
+    if (component.dataSrc !== 'resource' || !component.data?.resource) {
+        return false;
+    }
+
+    return true;
+};
+
+export const validateResourceSelectValue: RuleFn = async (context: ValidationContext) => {
+    const { value, config, component } = context;
+    if (!shouldValidate(context)) {
+        return null;
+    }
+
+    if (!config || !config.database) {
+        throw new ValidatorError("Can't validate for resource value without a database config object");
+    }
+    try {
+        const resourceSelectValueResult: boolean = await config.database?.validateResourceSelectValue(context, value);
+        return (resourceSelectValueResult === true) ? null : new FieldError('select', context);
+    }
+    catch (err: any) {
+        throw new ValidatorError(err.message || err);
+    }
+};
+
+export const validateResourceSelectValueInfo: ProcessorInfo<ValidationContext, FieldError | null> = {
+    name: 'validateResourceSelectValue',
+    process: validateResourceSelectValue,
+    shouldProcess: shouldValidate,
+}

--- a/src/process/validation/rules/validateUrlSelectValue.ts
+++ b/src/process/validation/rules/validateUrlSelectValue.ts
@@ -1,0 +1,132 @@
+import { FieldError, ValidatorError } from 'error';
+import { SelectComponent, RuleFn, ValidationContext, RuleFnSync, FetchFn } from 'types';
+import { Evaluator } from 'utils';
+import { isEmptyObject, toBoolean } from '../util';
+import { getErrorMessage } from 'utils/error';
+import { ProcessorInfo } from 'types/process/ProcessorInfo';
+
+const isValidatableSelectComponent = (component: any): component is SelectComponent => {
+    return (
+        component &&
+        component.type === 'select' &&
+        toBoolean(component.dataSrc === 'url') &&
+        toBoolean(component.validate?.select)
+    );
+};
+
+export const generateUrl = (baseUrl: URL, component: SelectComponent, value: any) => {
+    const url = baseUrl;
+    const query = url.searchParams;
+    if (component.searchField) {
+        let searchValue = value;
+        if (component.valueProperty) {
+            searchValue = value[component.valueProperty];
+        } else {
+            searchValue = value;
+        }
+        query.set(component.searchField, typeof searchValue === 'string' ? searchValue : JSON.stringify(searchValue))
+    }
+    if (component.selectFields) {
+        query.set('select', component.selectFields);
+    }
+    if (component.sort) {
+        query.set('sort', component.sort);
+    }
+    if (component.filter) {
+        const filterQueryStrings = new URLSearchParams(component.filter);
+        filterQueryStrings.forEach((value, key) => query.set(key, value));
+    }
+    return url;
+};
+
+export const shouldValidate = (context: ValidationContext) => {
+    const { component, value, data, config } = context;
+    // Only run this validation if server-side
+    if (!config?.server) {
+        return false;
+    }
+    if (!isValidatableSelectComponent(component)) {
+        return false;
+    }
+    if (
+        !value ||
+        isEmptyObject(value) ||
+        (Array.isArray(value) && (value as Array<Record<string, any>>).length === 0)
+    ) {
+        return false;
+    }
+
+    // If given an invalid configuration, do not validate the remote value
+    if (component.dataSrc !== 'url' || !component.data?.url || !component.searchField) {
+        return false;
+    }
+
+    return true;
+};
+
+export const validateUrlSelectValue: RuleFn = async (context: ValidationContext) => {
+    const { component, value, data, config } = context;
+    let _fetch: FetchFn | null = null;
+    try {
+        _fetch = context.fetch ? context.fetch : fetch;
+    }
+    catch (err) {
+        _fetch = null;
+    }
+    try {
+        if (!_fetch) {
+            console.log('You must provide a fetch interface to the fetch processor.');
+            return null;
+        }
+        if (!shouldValidate(context)) {
+            return null;
+        }
+
+        const baseUrl = new URL(
+            Evaluator ? Evaluator.interpolate((component as any).data.url, data, {}) : (component as any).data.url
+        );
+        const url = generateUrl(baseUrl, component as SelectComponent, value);
+        const headers: Record<string, string> = (component as any).data.headers
+            ? (component as any).data.headers.reduce(
+                  (acc: any, header: any) => ({ ...acc, [header.key]: header.value }),
+                  {}
+              )
+            : {};
+
+        // Set form.io authentication
+        if ((component as SelectComponent).authenticate && config && config.tokens) {
+            Object.assign(headers, config.tokens);
+        }
+
+        try {
+            const response = await _fetch(url.toString(), { method: 'GET', headers });
+            // TODO: should we always expect JSON here?
+            if (response.ok) {
+                const data = await response.json();
+                const error = new FieldError('select', context);
+                if (Array.isArray(data)) {
+                    return data && data.length ? null : error;
+                }
+                return data ? (isEmptyObject(data) ? error : null) : error;
+            }
+            const data = await response.text();
+            throw new ValidatorError(
+                `Component with path ${component.key} returned an error while validating remote value: ${data}`,
+            );
+        } catch (err) {
+            throw new ValidatorError(
+                `Component with path ${component.key} returned an error while validating remote value: ${err}`,
+            );
+        }
+    }
+    catch (err) {
+        console.error(getErrorMessage(err));
+        return null;
+    }
+};
+
+export const validateUrlSelectValueInfo: ProcessorInfo<ValidationContext, FieldError | null> = {
+    name: 'validateUrlSelectValue',
+    process: validateUrlSelectValue,
+    shouldProcess: shouldValidate,
+}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7964

## Description

The @formio/core library previously didn't account for select components that used a "resource" `dataSrc` property. This PR adds a validation rule that calls back to a database configuration to validate select component values versus the referenced resource.

## Breaking Changes / Backwards Compatibility

Since this seemed to be broken (in formio-enterprise 8.5.0 e.g.) before we moved validation to this library, I don't really forsee any problems here. That said, we should extensively test this functionality.

## Dependencies

[formio#]()

## How has this PR been tested?

Because the module in the core library is simple because it merely calls back to a database configuration function, no tests were added here. However, I did add tests to the dependent PR above.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
