### PR TITLE
FIO-8055: validate components that include custom validations, even when their data is empty

### DIFF
--- a/src/process/validation/rules/__tests__/validateCustom.test.ts
+++ b/src/process/validation/rules/__tests__/validateCustom.test.ts
@@ -36,3 +36,19 @@ it('A custom validation that includes data will correctly be interpolated', asyn
     const result = await validateCustom(context);
     expect(result).to.equal(null);
 });
+
+it('A custom validation of empty component data will still validate', async () => {
+    const component: TextFieldComponent = {
+        ...simpleTextField,
+        validate: {
+            custom: 'valid = data.simpleComponent === "any thing" ? true : "Invalid entry"',
+        },
+    };
+    const data = {
+        simpleComponent: '',
+    };
+    const context = generateProcessContext(component, data);
+    const result = await validateCustom(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result && result.errorKeyOrMessage).to.equal('Invalid entry');
+});

--- a/src/process/validation/rules/validateCustom.ts
+++ b/src/process/validation/rules/validateCustom.ts
@@ -12,7 +12,7 @@ export const validateCustom: RuleFn = async (context: ValidationContext) => {
 export const shouldValidate = (context: ValidationContext) => {
     const { component, value } = context;
     const customValidation = component.validate?.custom;
-    if (!customValidation || !value || ((typeof value === 'string' || typeof value === 'object') && isEmpty(value))) {
+    if (!customValidation) {
         return false;
     }
     return true;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8055

## Description

When porting over validation logic, I included [preexisting logic that would not custom validate components with empty data unless they were required](https://github.com/formio/formio.js/pull/5398/files). This was later reverted as an error, and so needs to be included in core's validation logic.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I've added an automated test to record expected behavior. Additionally, all formio and formio-server tests pass with this change included.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
