### PR TITLE
FIO 8049: fix value prop in evaluations

### DIFF
--- a/src/process/calculation/__tests__/calculation.test.ts
+++ b/src/process/calculation/__tests__/calculation.test.ts
@@ -36,15 +36,49 @@ describe('Calculation processor', () => {
                 }
             ]
         };
-    
+
         const submission = {
             data: {
                 a: 1,
                 b: 2
             }
         };
-    
+
         const context: ProcessContext<CalculationScope> = await processForm(form, submission);
         expect(context.data.c).to.equal(3);
+    });
+
+    it('Calculation processor will perform a simple calculation that overwrites the value prop', async () => {
+        const form = {
+            components: [
+                {
+                    type: 'number',
+                    key: 'a',
+                    input: true
+                },
+                {
+                    type: 'number',
+                    key: 'b',
+                    input: true
+                },
+                {
+                    type: 'number',
+                    key: 'c',
+                    input: true,
+                    calculateValue: 'value = value + data.a + data.b'
+                }
+            ]
+        };
+
+        const submission = {
+            data: {
+                a: 1,
+                b: 2,
+                c: 3,
+            }
+        };
+
+        const context: ProcessContext<CalculationScope> = await processForm(form, submission);
+        expect(context.data.c).to.equal(6);
     });
 });

--- a/src/process/calculation/index.ts
+++ b/src/process/calculation/index.ts
@@ -15,12 +15,12 @@ export const shouldCalculate = (context: CalculationContext): boolean => {
 };
 
 export const calculateProcessSync: ProcessorFnSync<CalculationScope> = (context: CalculationContext) => {
-    const { component, data, evalContext, scope, path } = context;
+    const { component, data, evalContext, scope, path, value } = context;
     if (!shouldCalculate(context)) {
         return;
     }
     const evalContextValue = evalContext ? evalContext(context) : context;
-    evalContextValue.value = null;
+    evalContextValue.value = value || null;
     if (!scope.calculated) scope.calculated = [];
     let newValue = Evaluator.evaluate(component.calculateValue, evalContextValue, 'value');
 

--- a/src/process/processOne.ts
+++ b/src/process/processOne.ts
@@ -12,6 +12,7 @@ export async function processOne<ProcessorScope>(context: ProcessorsContext<Proc
     // Create a getter for `value` that is always derived from the current data object
     if (typeof context.value === 'undefined') {
         Object.defineProperty(context, 'value', {
+            enumerable: true,
             get() {
                 return get(context.data, context.path);
             },
@@ -36,6 +37,7 @@ export function processOneSync<ProcessorScope>(context: ProcessorsContext<Proces
     // Create a getter for `value` that is always derived from the current data object
     if (typeof context.value === 'undefined') {
         Object.defineProperty(context, 'value', {
+            enumerable: true,
             get() {
                 return get(context.data, context.path);
             },

--- a/src/utils/Evaluator.ts
+++ b/src/utils/Evaluator.ts
@@ -113,7 +113,7 @@ export class BaseEvaluator {
         const componentKey = component.key;
         if (typeof func === 'string') {
             if (ret) {
-                func = `var ${ret};${func};return ${ret}`;
+                func = args[ret] ? `${func};return ${ret}` : `var ${ret};${func};return ${ret}`;
             }
 
             if (interpolate) {

--- a/src/utils/Evaluator.ts
+++ b/src/utils/Evaluator.ts
@@ -113,7 +113,7 @@ export class BaseEvaluator {
         const componentKey = component.key;
         if (typeof func === 'string') {
             if (ret) {
-                func = args[ret] ? `${func};return ${ret}` : `var ${ret};${func};return ${ret}`;
+                func = `var ${ret};${func};return ${ret}`;
             }
 
             if (interpolate) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8049

## Description

* Since `value` is now a getter, we need to make it enumerable so that the Evaluator [correctly enumerates it]( into the arguments of the Function
* We also want to make sure that the component's value, if it exists, is passed in to the evaluation context

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I added an automated test to describe behavior and the existing formio and formio-server tests are passing.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
