### PR TITLE
FIO-8047: add dereferencing processor for datatable comp

### DIFF
--- a/src/error/DereferenceError.ts
+++ b/src/error/DereferenceError.ts
@@ -1,0 +1,1 @@
+export class DereferenceError extends Error {};

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,2 +1,3 @@
 export * from './FieldError';
 export * from './ValidatorError';
+export * from './DereferenceError';

--- a/src/process/dereference/index.ts
+++ b/src/process/dereference/index.ts
@@ -7,6 +7,7 @@ import {
     Component,
     DataTableComponent
 } from "types";
+import { fastCloneDeep } from "utils";
 
 type DereferenceScope = ProcessorScope & {
     dereference: {
@@ -41,10 +42,11 @@ export const dereferenceProcess: ProcessorFn<DereferenceScope> = async (context)
 
     try {
         const components = await config.database?.dereferenceDataTableComponent(component);
-        scope.dereference[path] = components;
+        const vmCompatibleComponents = fastCloneDeep(components);
+        scope.dereference[path] = vmCompatibleComponents;
         // Modify the components in place; we have to do this now as opposed to a "post-processor" step because
         // eachComponentDataAsync will immediately turn around and introspect these components in the case of Data Table
-        component.components = components;
+        component.components = vmCompatibleComponents;
     }
     catch (err: any) {
         throw new DereferenceError(err.message || err);

--- a/src/process/dereference/index.ts
+++ b/src/process/dereference/index.ts
@@ -1,0 +1,58 @@
+import { DereferenceError } from "error";
+import {
+    ProcessorFn,
+    ProcessorScope,
+    ProcessorContext,
+    ProcessorInfo,
+    Component,
+    DataTableComponent
+} from "types";
+
+type DereferenceScope = ProcessorScope & {
+    dereference: {
+        [path: string]: Component[];
+    }
+}
+
+const isDereferenceableDataTableComponent = (component: any): component is DataTableComponent => {
+    return component
+      && component.type === 'datatable'
+      && component.fetch?.enableFetch === true
+      && component.fetch?.dataSrc === 'resource'
+      && typeof component.fetch?.resource === 'string';
+}
+
+/**
+ * This function is used to dereference reference IDs contained in the form.
+ * It is currently only compatible with Data Table components.
+ * @todo Add support for other components (if applicable) and for submission data dereferencing (e.g. save-as-reference, currently a property action).
+ */
+export const dereferenceProcess: ProcessorFn<DereferenceScope> = async (context) => {
+    const { component, config, scope, path } = context;
+    if (!scope.dereference) {
+        scope.dereference = {};
+    }
+    if (!isDereferenceableDataTableComponent(component)) {
+        return;
+    }
+    if (!config?.database) {
+        throw new DereferenceError('Cannot dereference resource value without a database config object');
+    }
+
+    try {
+        const components = await config.database?.dereferenceDataTableComponent(component);
+        scope.dereference[path] = components;
+        // Modify the components in place; we have to do this now as opposed to a "post-processor" step because
+        // eachComponentDataAsync will immediately turn around and introspect these components in the case of Data Table
+        component.components = components;
+    }
+    catch (err: any) {
+        throw new DereferenceError(err.message || err);
+    }
+}
+
+export const dereferenceProcessInfo: ProcessorInfo<ProcessorContext<DereferenceScope>, void> = {
+    name: 'dereference',
+    shouldProcess: () => true,
+    process: dereferenceProcess,
+}

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -9,3 +9,4 @@ export * from './populate';
 export * from './processOne';
 export * from './process';
 export * from './normalize';
+export * from './dereference';

--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -11,6 +11,7 @@ import { conditionProcessInfo, customConditionProcessInfo, simpleConditionProces
 import { validateCustomProcessInfo, validateProcessInfo, validateServerProcessInfo } from "./validation";
 import { filterProcessInfo } from "./filter";
 import { normalizeProcessInfo } from "./normalize";
+import { dereferenceProcessInfo } from "./dereference";
 
 export async function process<ProcessScope>(context: ProcessContext<ProcessScope>): Promise<ProcessScope> {
     const { instances, components, data, scope, flat, processors } = context;
@@ -89,6 +90,7 @@ export const ProcessorMap: Record<string, ProcessorInfo<any, any>> = {
     customConditions: customConditionProcessInfo,
     simpleConditions: simpleConditionProcessInfo,
     normalize: normalizeProcessInfo,
+    dereference: dereferenceProcessInfo,
     fetch: fetchProcessInfo,
     logic: logicProcessInfo,
     validate: validateProcessInfo,
@@ -101,6 +103,7 @@ export const ProcessTargets: ProcessTarget = {
         filterProcessInfo,
         serverDefaultValueProcessInfo,
         normalizeProcessInfo,
+        dereferenceProcessInfo,
         fetchProcessInfo,
         simpleConditionProcessInfo,
         validateServerProcessInfo

--- a/src/types/Component.ts
+++ b/src/types/Component.ts
@@ -163,6 +163,17 @@ export type DataSourceComponent = BaseComponent & {
     };
 };
 
+export type DataTableComponent = EditGridComponent & {
+    fetch?: {
+        enableFetch: boolean;
+        dataSrc: 'resource' | 'url';
+        sort?: { defaultQuery?: string };
+        resource?: string;
+        headers?: { key: string; value: string }[];
+        components?: { key: string; path: string }[] | Component[];
+    }
+}
+
 export type DateTimeComponent = BaseComponent & {
     format?: string;
     useLocaleSettings?: boolean;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8047

## Description

Because Data Table components have an array data model, the `filter` process will skip over their submission data with the expectation that their constituent components will be iterated over by `eachComponentData`. However, Data Table components that use the "Reference" data source populate their components at runtime, which means that the form component that the server has access to has only an empty array. This PR adds a "dereference" processor (similar to the existing field action that serves save-as-reference submission data) that dereferences a target resource's components and populates the component's `components` array with those component JSON definitions so that the server can correctly iterate over and validate them. 

This can and should eventually be expanded to cover all dereferencing use cases such as save-as-reference submission objects or other components that lazily load their constituent components from a resource.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

[formio#1720](https://github.com/formio/formio/pull/1720)

## How has this PR been tested?

Much like `isUnique` or `validateRecaptcha`, this processor calls back to the Form.io server to access database-level data. Therefore, it's difficult to fully test in the core library, and integration tests should be performed as part of the server's test suite.
 
## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
