### PR TITLE
FIO-8079: add stricter time validation

### DIFF
--- a/src/process/__tests__/fixtures/util.ts
+++ b/src/process/__tests__/fixtures/util.ts
@@ -1,0 +1,12 @@
+import get from 'lodash/get';
+import { ProcessorContext, ProcessorScope, Component } from 'types';
+export const generateProcessorContext = (component: Component, data: any): ProcessorContext<ProcessorScope> => {
+    return {
+        component,
+        path: component.key,
+        data,
+        row: data,
+        scope: {} as ProcessorScope,
+        value: get(data, component.key),
+    }
+}

--- a/src/process/normalize/__tests__/normalize.test.ts
+++ b/src/process/normalize/__tests__/normalize.test.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+
+import { TimeComponent } from 'types';
+import { normalizeProcessSync } from '../';
+import { generateProcessorContext } from '../../__tests__/fixtures/util';
+
+const timeField: TimeComponent = {
+    type: 'time',
+    key: 'time',
+    label: 'Time',
+    input: true,
+    dataFormat: 'HH:mm:ss'
+};
+
+it('Should normalize a time component with a valid time value that doees not match dataFormat', async () => {
+    const data = { time: '12:00' };
+    const context = generateProcessorContext(timeField, data);
+    normalizeProcessSync(context);
+    expect(context.data).to.deep.equal({time: '12:00:00'});
+});

--- a/src/process/validation/i18n/en.ts
+++ b/src/process/validation/i18n/en.ts
@@ -33,5 +33,6 @@ export const EN_ERRORS = {
     valueIsNotAvailable: '{{ field }} is an invalid value.',
     captchaTokenValidation: 'ReCAPTCHA: Token validation error',
     captchaTokenNotSpecified: 'ReCAPTCHA: Token is not specified in submission',
-    captchaFailure: 'ReCaptcha: Response token not found'
+    captchaFailure: 'ReCaptcha: Response token not found',
+    time: '{{field}} is not a valid time.',
 };

--- a/src/process/validation/rules/__tests__/fixtures/util.ts
+++ b/src/process/validation/rules/__tests__/fixtures/util.ts
@@ -1,10 +1,10 @@
 import { get } from "lodash";
 import { Component, DataObject, ProcessorType, ValidationContext } from "types";
 
-export const generateProcessContext = (component: Component, data: DataObject): ValidationContext => {
+export const generateProcessorContext = (component: Component, data: DataObject): ValidationContext => {
     const path = component.key;
     const value = get(data, path);
-    return { 
+    return {
         component,
         data,
         scope: {errors: []},

--- a/src/process/validation/rules/__tests__/validateAvailableItems.test.ts
+++ b/src/process/validation/rules/__tests__/validateAvailableItems.test.ts
@@ -8,7 +8,7 @@ import {
     simpleTextField,
     simpleSelectOptions,
 } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateAvailableItems } from '../validateAvailableItems';
 
 it('Validating a component without the available items validation parameter will return null', async () => {
@@ -16,7 +16,7 @@ it('Validating a component without the available items validation parameter will
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -31,7 +31,7 @@ it('Validating a simple select boxes component without the available items valid
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a simple radio component without the available items validation p
     const data = {
         component: 'bar',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -54,7 +54,7 @@ it('Validating a simple radio component with the available items validation para
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidOption');
@@ -76,7 +76,7 @@ it('Validating a simple static values select component without the available ite
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -98,7 +98,7 @@ it('Validating a simple static values select component with the available items 
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -115,7 +115,7 @@ it('Validating a simple URL select component without the available items validat
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -131,7 +131,7 @@ it('Validating a simple JSON select component (string JSON) without the availabl
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -148,7 +148,7 @@ it('Validating a simple JSON select component (string JSON) with the available i
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidOption');
@@ -166,7 +166,7 @@ it('Validating a simple JSON select component (string JSON) with the available i
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -183,7 +183,7 @@ it('Validating a simple JSON select component (nested string JSON) with the avai
     const data = {
         component: { foo: 'foo', bar: 'bar' },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -200,7 +200,7 @@ it('Validating a simple JSON select component (nested string JSON) with the avai
     const data = {
         component: { foo: 'bar', bar: 'baz' },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidOption');
@@ -219,7 +219,7 @@ it('Validating a simple JSON select component (nested string JSON with valueProp
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidOption');
@@ -238,7 +238,7 @@ it('Validating a simple JSON select component (nested string JSON with valueProp
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -254,7 +254,7 @@ it('Validating a simple JSON select component (actual JSON) without the availabl
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -271,7 +271,7 @@ it('Validating a simple JSON select component (actual JSON) with the available i
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidOption');
@@ -289,7 +289,7 @@ it('Validating a simple JSON select component (actual JSON) with the available i
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -309,7 +309,7 @@ it('Validating a simple JSON select component (nested actual JSON) with the avai
     const data = {
         component: { foo: 'baz', bar: 'biz' },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidOption');
@@ -330,7 +330,7 @@ it('Validating a simple JSON select component (nested actual JSON) with the avai
     const data = {
         component: { foo: 'foo', bar: 'bar' },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });
@@ -351,7 +351,7 @@ it('Validating a simple JSON select component (nested actual JSON with valueProp
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidOption');
@@ -373,7 +373,7 @@ it('Validating a simple JSON select component (nested actual JSON with valueProp
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateCustom.test.ts
+++ b/src/process/validation/rules/__tests__/validateCustom.test.ts
@@ -4,7 +4,7 @@ import { FieldError } from 'error';
 import { TextFieldComponent } from 'types';
 import { simpleTextField } from './fixtures/components';
 import { validateCustom } from '../validateCustom';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 
 it('A simple custom validation will correctly be interpolated', async () => {
     const component: TextFieldComponent = {
@@ -16,7 +16,7 @@ it('A simple custom validation will correctly be interpolated', async () => {
     const data = {
         component: 'any thing',
     }
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateCustom(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result && result.errorKeyOrMessage).to.equal('Invalid entry');
@@ -32,7 +32,7 @@ it('A custom validation that includes data will correctly be interpolated', asyn
     const data = {
         simpleComponent: 'any thing',
     }
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateCustom(context);
     expect(result).to.equal(null);
 });
@@ -47,7 +47,7 @@ it('A custom validation of empty component data will still validate', async () =
     const data = {
         simpleComponent: '',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateCustom(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result && result.errorKeyOrMessage).to.equal('Invalid entry');

--- a/src/process/validation/rules/__tests__/validateDate.test.ts
+++ b/src/process/validation/rules/__tests__/validateDate.test.ts
@@ -3,14 +3,14 @@ import { expect } from 'chai';
 import { FieldError } from 'error';
 import { calendarTextField, simpleDateTimeField, simpleTextField } from './fixtures/components';
 import { validateDate } from '../validateDate';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 
 it('Validating a component without a date/time concern will return null', async () => {
     const component = simpleTextField;
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.equal(null);
 });
@@ -18,7 +18,7 @@ it('Validating a component without a date/time concern will return null', async 
 it('Validating a date/time component with no data will return null', async () => {
     const component = simpleDateTimeField;
     const data = {};
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.equal(null);
 });
@@ -28,7 +28,7 @@ it('Validating a date/time component with an invalid date string value will retu
     const data = {
         component: 'hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidDate');
@@ -39,7 +39,7 @@ it('Validating a date/time component with an valid date string value will return
     const data = {
         component: '2023-03-09T12:00:00-06:00',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.equal(null);
 });
@@ -49,7 +49,7 @@ it('Validating a date/time component with an invalid Date object will return a F
     const data = {
         component: new Date('Hello, world!'),
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidDate');
@@ -60,7 +60,7 @@ it('Validating a date/time component with a valid Date object will return null',
     const data = {
         component: new Date(),
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.equal(null);
 });
@@ -68,7 +68,7 @@ it('Validating a date/time component with a valid Date object will return null',
 it('Validating a textField calendar picker component with no data will return null', async () => {
     const component = calendarTextField;
     const data = {};
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.equal(null);
 });
@@ -78,7 +78,7 @@ it('Validating a textField calendar picker component with an invalid date string
     const data = {
         component: 'hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidDate');
@@ -89,7 +89,7 @@ it('Validating a textField calendar picker component with an valid date string v
     const data = {
         component: '2023-03-09T12:00:00-06:00',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.equal(null);
 });
@@ -99,7 +99,7 @@ it('Validating a textField calendar picker component with an invalid Date object
     const data = {
         component: new Date('Hello, world!'),
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidDate');
@@ -110,7 +110,7 @@ it('Validating a textField calendar picker component with a valid Date object wi
     const data = {
         component: new Date(),
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateDay.test.ts
+++ b/src/process/validation/rules/__tests__/validateDay.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleDayField, simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateDay } from '../validateDay';
 
 it('Validating a non-day component will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a non-day component will return null', async () => {
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDay(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a day component with an invalid date string value will return a F
     const data = {
         component: 'hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDay(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidDay');
@@ -31,7 +31,7 @@ it('Validating a day component with an valid date string value will return null'
     const data = {
         component: '03/23/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDay(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a day component with an invalid Date object will return a FieldEr
     const data = {
         component: new Date('Hello, world!'),
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDay(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidDay');
@@ -52,7 +52,7 @@ it('Validating a day component with a valid Date object will return a field erro
     const data = {
         component: new Date(),
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateDay(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidDay');

--- a/src/process/validation/rules/__tests__/validateEmail.test.ts
+++ b/src/process/validation/rules/__tests__/validateEmail.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleEmailField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateEmail } from '../validateEmail';
 
 it('Validating a valid email will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a valid email will return null', async () => {
     const data = {
         component: 'sales@form.io',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateEmail(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating an invalid email will return a FieldError', async () => {
     const data = {
         component: 'salesatform.io',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateEmail(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('invalid_email');

--- a/src/process/validation/rules/__tests__/validateJson.test.ts
+++ b/src/process/validation/rules/__tests__/validateJson.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error/FieldError';
 import { simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateJson } from '../validateJson';
 
 it('A simple component without JSON logic validation will return null', async () => {
@@ -10,7 +10,7 @@ it('A simple component without JSON logic validation will return null', async ()
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateJson(context);
     expect(result).to.equal(null);
 });
@@ -38,7 +38,7 @@ it('A simple component with JSON logic evaluation will return a FieldError if th
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateJson(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('Input must be \'foo\'');
@@ -67,7 +67,7 @@ it('A simple component with JSON logic evaluation will return null if the JSON l
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateJson(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMask.test.ts
+++ b/src/process/validation/rules/__tests__/validateMask.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { FieldError } from 'error';
 import { simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMask } from '../validateMask';
 
 it('Validating a mask component should return a FieldError if the value does not match the mask', async () => {
@@ -9,7 +9,7 @@ it('Validating a mask component should return a FieldError if the value does not
     const data = {
         component: '1234',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMask(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('mask');
@@ -20,7 +20,7 @@ it('Validating a mask component should return null if the value matches the mask
     const data = {
         component: '123-456-7890',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMask(context);
     expect(result).to.equal(null);
 });
@@ -43,7 +43,7 @@ it('Validating a multi-mask component should return a FieldError if the value do
     let data = {
         component: { maskName: 'maskOne', value: '14567890' },
     };
-    let context = generateProcessContext(component, data);
+    let context = generateProcessorContext(component, data);
     let result = await validateMask(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('mask');
@@ -51,7 +51,7 @@ it('Validating a multi-mask component should return a FieldError if the value do
     data = {
         component: { maskName: 'maskTwo', value: '1234567' },
     };
-    context = generateProcessContext(component, data);
+    context = generateProcessorContext(component, data);
     result = await validateMask(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('mask');
@@ -75,14 +75,14 @@ it('Validating a mutil-mask component should return null if the value matches th
     let data = {
         component: { maskName: 'maskOne', value: '456-7890' },
     };
-    let context = generateProcessContext(component, data);
+    let context = generateProcessorContext(component, data);
     let result = await validateMask(context);
     expect(result).to.equal(null);
 
     data = {
         component: { maskName: 'maskTwo', value: '123-456-7890' },
     };
-    context = generateProcessContext(component, data);
+    context = generateProcessorContext(component, data);
     result = await validateMask(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMaximumDay.test.ts
+++ b/src/process/validation/rules/__tests__/validateMaximumDay.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleDayField, simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMaximumDay } from '../validateMaximumDay';
 
 it('Validating a non-day component will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a non-day component will return null', async () => {
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumDay(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a day component with a day after the maximum day will return a Fi
     const data = {
         component: '04/02/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumDay(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('maxDay');
@@ -31,7 +31,7 @@ it('Validating a day component with a day before the maximum day will return nul
     const data = {
         component: '03/23/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumDay(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a day component with a day after the maximum day will return a Fi
     const data = {
         component: '04/02/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumDay(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('maxDay');
@@ -52,7 +52,7 @@ it('Validating a day-first day component with a day after the maximum day will r
     const data = {
         component: '02/04/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumDay(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('maxDay');
@@ -63,7 +63,7 @@ it('Validating a day-first day component with a day before the maximum day will 
     const data = {
         component: '23/03/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumDay(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMaximumLength.test.ts
+++ b/src/process/validation/rules/__tests__/validateMaximumLength.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMaximumLength } from '../validateMaximumLength';
 
 it('Validating a component without a maxLength property will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a component without a maxLength property will return null', async
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumLength(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a component with a maxLength property and a length greater than m
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumLength(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('maxLength');
@@ -31,7 +31,7 @@ it('Validating a component with a maxLength property and a length less than maxL
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumLength(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a component with a maxLength property that is an empty string wil
     const data = {
         component: '',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumLength(context);
     expect(result).to.equal(null);
 })

--- a/src/process/validation/rules/__tests__/validateMaximumSelectedCount.test.ts
+++ b/src/process/validation/rules/__tests__/validateMaximumSelectedCount.test.ts
@@ -3,14 +3,14 @@ import { expect } from 'chai';
 import { FieldError } from 'error';
 import { simpleSelectBoxes, simpleTextField } from './fixtures/components';
 import { validateMaximumSelectedCount } from '../validateMaximumSelectedCount';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 
 it('Validting a non-select boxes component will return null', async () => {
     const component = simpleTextField;
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumSelectedCount(context);
     expect(result).to.equal(null);
 });
@@ -25,7 +25,7 @@ it('Validating a select boxes component without maxSelectedCount will return nul
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumSelectedCount(context);
     expect(result).to.equal(null);
 });
@@ -40,7 +40,7 @@ it('Validating a select boxes component where the number of selected fields is g
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumSelectedCount(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('maxSelectedCount');
@@ -56,7 +56,7 @@ it('Validating a select boxes component where the number of selected fields is e
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumSelectedCount(context);
     expect(result).to.equal(null);
 });
@@ -71,7 +71,7 @@ it('Validating a select boxes component where the number of selected fields is l
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumSelectedCount(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMaximumValue.test.ts
+++ b/src/process/validation/rules/__tests__/validateMaximumValue.test.ts
@@ -3,14 +3,14 @@ import { expect } from 'chai';
 import { FieldError } from 'error';
 import { simpleNumberField, simpleTextField } from './fixtures/components';
 import { validateMaximumValue } from '../validateMaximumValue';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 
 it('Validating a component without the max property will return null', async () => {
     const component = simpleTextField;
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumValue(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a number component without the max property will return null', as
     const data = {
         component: 3,
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumValue(context);
     expect(result).to.equal(null);
 });
@@ -30,7 +30,7 @@ it('Validating a number component that contains the max property will return nul
     const data = {
         component: 35,
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumValue(context);
     expect(result).to.equal(null);
 });
@@ -40,7 +40,7 @@ it('Validating a number component that contains the max property will return a F
     const data = {
         component: 55,
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumValue(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('max');
@@ -51,7 +51,7 @@ it('Validating a number component that contains the max property will return nul
     const data = {
         component: 50,
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumValue(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMaximumWords.test.ts
+++ b/src/process/validation/rules/__tests__/validateMaximumWords.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMaximumWords } from '../validateMaximumWords';
 
 it('Validating a component without the maxWords property will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a component without the maxWords property will return null', asyn
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumWords(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a component with the maxWords property will return a FieldError i
     const data = {
         component: "Hello, world, it's me!",
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumWords(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('maxWords');
@@ -31,7 +31,7 @@ it('Validating a component with the maxWords property will return null if the nu
     const data = {
         component: 'Hello, world, again!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumWords(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a component with the maxWords property will return null if the nu
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumWords(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMaximumYear.test.ts
+++ b/src/process/validation/rules/__tests__/validateMaximumYear.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { DayComponent } from 'types';
 import { FieldError } from 'error';
 import { simpleDayField, simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMaximumYear } from '../validateMaximumYear';
 
 it('Validating a component without the maxYear parameter will return null', async () => {
@@ -11,7 +11,7 @@ it('Validating a component without the maxYear parameter will return null', asyn
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumYear(context);
     expect(result).to.equal(null);
 });
@@ -21,7 +21,7 @@ it('Validating a day component without the maxYear parameter will return null', 
     const data = {
         component: '01/22/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumYear(context);
     expect(result).to.equal(null);
 });
@@ -38,7 +38,7 @@ it('Validating a day component with the maxYear parameter will return a FieldErr
     const data = {
         component: '01/22/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumYear(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('maxYear');
@@ -56,7 +56,7 @@ it('Validating a day component with the maxYear parameter will return null if th
     const data = {
         component: '01/22/2022',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumYear(context);
     expect(result).to.equal(null);
 });
@@ -73,7 +73,7 @@ it('Validating a day component with the maxYear parameter will return null if th
     const data = {
         component: '01/22/2021',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMaximumYear(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMinimumDay.test.ts
+++ b/src/process/validation/rules/__tests__/validateMinimumDay.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleDayField, simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMinimumDay } from '../validateMinimumDay';
 
 it('Validating a non-day component will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a non-day component will return null', async () => {
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumDay(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a day component with a day before the minimum day will return a F
     const data = {
         component: '03/23/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumDay(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('minDay');
@@ -31,7 +31,7 @@ it('Validating a day component with a day after the minimum day will return null
     const data = {
         component: '04/02/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumDay(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a day-first day component with a day before the minimum day will 
     const data = {
         component: '02/02/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumDay(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('minDay');
@@ -52,7 +52,7 @@ it('Validating a day-first day component with a day after the minimum day will r
     const data = {
         component: '23/04/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumDay(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMinimumLength.test.ts
+++ b/src/process/validation/rules/__tests__/validateMinimumLength.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMinimumLength } from '../validateMinimumLength';
 
 it('Validating a component without a minLength property will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a component without a minLength property will return null', async
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumLength(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a component with a minLength property and a length less than minL
     const data = {
         component: 'foo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumLength(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('minLength');
@@ -31,7 +31,7 @@ it('Validating a component with a minLength property and a length equal to minLe
     const data = {
         component: 'fooo',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumLength(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a component with a minLength property and a length greater than m
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumLength(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMinimumSelectedCount.test.ts
+++ b/src/process/validation/rules/__tests__/validateMinimumSelectedCount.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleSelectBoxes, simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMinimumSelectedCount } from '../validateMinimumSelectedCount';
 
 it('Validting a non-select boxes component will return null', async () => {
@@ -10,7 +10,7 @@ it('Validting a non-select boxes component will return null', async () => {
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumSelectedCount(context);
     expect(result).to.equal(null);
 });
@@ -25,7 +25,7 @@ it('Validating a select boxes component without minSelectedCount will return nul
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumSelectedCount(context);
     expect(result).to.equal(null);
 });
@@ -40,7 +40,7 @@ it('Validating a select boxes component where the number of selected fields is l
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumSelectedCount(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('minSelectedCount');
@@ -56,7 +56,7 @@ it('Validating a select boxes component where the number of selected fields is e
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumSelectedCount(context);
     expect(result).to.equal(null);
 });
@@ -71,7 +71,7 @@ it('Validating a select boxes component where the number of selected fields is g
             biz: false,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumSelectedCount(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMinimumValue.test.ts
+++ b/src/process/validation/rules/__tests__/validateMinimumValue.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleNumberField, simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMinimumValue } from '../validateMinimumValue';
 
 it('Validating a component without the min property will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a component without the min property will return null', async () 
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumValue(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a number component without the min property will return null', as
     const data = {
         component: 3,
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumValue(context);
     expect(result).to.equal(null);
 });
@@ -30,7 +30,7 @@ it('Validating a number component that contains the min property will return nul
     const data = {
         component: 55,
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumValue(context);
     expect(result).to.equal(null);
 });
@@ -40,7 +40,7 @@ it('Validating a number component that contains the min property will return a F
     const data = {
         component: 35,
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumValue(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('min');
@@ -51,7 +51,7 @@ it('Validating a number component that contains the min property will return nul
     const data = {
         component: 50,
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumValue(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMinimumWords.test.ts
+++ b/src/process/validation/rules/__tests__/validateMinimumWords.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMinimumWords } from '../validateMinimumWords';
 
 it('Validating a component without the maxWords property will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a component without the maxWords property will return null', asyn
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumWords(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a component with the minWords property will return a FieldError i
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumWords(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('minWords');
@@ -31,7 +31,7 @@ it('Validating a component with the minWords property will return null if the nu
     const data = {
         component: 'Hello, world, again!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumWords(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a component with the minWords property will return null if the nu
     const data = {
         component: 'Hello, world, it is I!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumWords(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateMinimumYear.test.ts
+++ b/src/process/validation/rules/__tests__/validateMinimumYear.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { DayComponent } from 'types';
 import { FieldError } from 'error';
 import { simpleDayField, simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateMinimumYear } from '../validateMinimumYear';
 
 it('Validating a component without the minYear parameter will return null', async () => {
@@ -11,7 +11,7 @@ it('Validating a component without the minYear parameter will return null', asyn
     const data = {
         component: 'Hello, world!',
     }
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumYear(context);
     expect(result).to.equal(null);
 });
@@ -21,7 +21,7 @@ it('Validating a day component without the minYear parameter will return null', 
     const data = {
         component: '01/22/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumYear(context);
     expect(result).to.equal(null);
 });
@@ -38,7 +38,7 @@ it('Validating a day component with the minYear parameter will return a FieldErr
     const data = {
         component: '01/22/2022',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumYear(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('minYear');
@@ -56,7 +56,7 @@ it('Validating a day component with the minYear parameter will return null if th
     const data = {
         component: '01/22/2022',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumYear(context);
     expect(result).to.equal(null);
 });
@@ -73,7 +73,7 @@ it('Validating a day component with the minYear parameter will return null if th
     const data = {
         component: '01/22/2023',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateMinimumYear(context);
     expect(result).to.equal(null);
 });

--- a/src/process/validation/rules/__tests__/validateRegexPattern.test.ts
+++ b/src/process/validation/rules/__tests__/validateRegexPattern.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateRegexPattern } from '../validateRegexPattern';
 
 it('Validating a component without a pattern parameter will return null', async () => {
@@ -10,7 +10,7 @@ it('Validating a component without a pattern parameter will return null', async 
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRegexPattern(context);
     expect(result).to.equal(null);
 });
@@ -20,7 +20,7 @@ it('Validating a component with a pattern parameter will return a FieldError if 
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRegexPattern(context);    expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('pattern');
 });
@@ -30,7 +30,7 @@ it('Validating a component with a pattern parameter will return null if the valu
     const data = {
         component: '12345',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRegexPattern(context);
     expect(result).to.equal(null);
 });
@@ -41,7 +41,7 @@ it('Validating a component with an empty value will not trigger the pattern vali
         component: ''
     };
 
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRegexPattern(context);
     expect(result).to.equal(null);
 })

--- a/src/process/validation/rules/__tests__/validateRemoteSelectValue.test.ts
+++ b/src/process/validation/rules/__tests__/validateRemoteSelectValue.test.ts
@@ -3,7 +3,7 @@ import { get } from 'lodash';
 import { DataObject, SelectComponent } from 'types';
 import { FieldError } from 'error';
 import { simpleSelectOptions, simpleTextField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateRemoteSelectValue, generateUrl } from '../validateRemoteSelectValue';
 
 it('Validating a component without the remote value validation parameter will return null', async () => {
@@ -11,7 +11,7 @@ it('Validating a component without the remote value validation parameter will re
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRemoteSelectValue(context);
     expect(result).to.equal(null);
 });
@@ -31,7 +31,7 @@ it('Validating a select component without the remote value validation parameter 
             value: 2,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRemoteSelectValue(context);
     expect(result).to.equal(null);
 });
@@ -83,7 +83,7 @@ it('Validating a select component with the remote validation parameter will retu
             value: 2,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRemoteSelectValue(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('select');
@@ -107,7 +107,7 @@ it('Validating a select component with the remote validation parameter will retu
             value: 2,
         },
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRemoteSelectValue(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('select');
@@ -132,7 +132,7 @@ it('Validating a select component with the remote validation parameter will retu
         },
     };
 
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     context.fetch = (url: string, options?: RequestInit | undefined) => {
         return Promise.resolve({
             ok: true,

--- a/src/process/validation/rules/__tests__/validateRequired.test.ts
+++ b/src/process/validation/rules/__tests__/validateRequired.test.ts
@@ -4,14 +4,14 @@ import { FieldError } from 'error';
 import { validateRequired } from '../validateRequired';
 import { conditionallyHiddenRequiredHiddenField, hiddenRequiredField, requiredNonInputField, simpleTextField } from './fixtures/components';
 import { processOne } from 'processes/processOne';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { ProcessorsContext, ValidationScope } from 'types';
 import { validateAllProcess, validateProcessInfo } from 'processes/validation';
 
 it('Validating a simple component that is required and not present in the data will return a field error', async () => {
     const component = { ...simpleTextField, validate: { required: true } };
     const data = {};
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRequired(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result && result.errorKeyOrMessage).to.equal('required');
@@ -20,7 +20,7 @@ it('Validating a simple component that is required and not present in the data w
 it('Validating a simple component that is required and present in the data will return null', async () => {
     const component = { ...simpleTextField, validate: { required: true } };
     const data = { component: 'a simple value' };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRequired(context);
     expect(result).to.equal(null);
 });
@@ -28,7 +28,7 @@ it('Validating a simple component that is required and present in the data will 
 it('Validating a simple component that is not required and present in the data will return null', async () => {
     const component = simpleTextField;
     const data = { component: 'a simple value' };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRequired(context);
     expect(result).to.equal(null);
 });
@@ -36,7 +36,7 @@ it('Validating a simple component that is not required and present in the data w
 it('Validating a simple component that is not required and not present in the data will return null', async () => {
     const component = simpleTextField;
     const data = {};
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateRequired(context);
     expect(result).to.equal(null);
 });
@@ -44,7 +44,7 @@ it('Validating a simple component that is not required and not present in the da
 it('Should validate a hidden component that does not contain data', async () => {
     const component = hiddenRequiredField;
     const data = {otherData: 'hideme'};
-    const context = generateProcessContext(component, data) as ProcessorsContext<ValidationScope>;
+    const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
     context.processors = [validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(1);
@@ -54,7 +54,7 @@ it('Should validate a hidden component that does not contain data', async () => 
 it('Should not validate a hidden component that is conditionally hidden', async () => {
     const component = conditionallyHiddenRequiredHiddenField;
     const data = {otherData: 'hideme'};
-    const context = generateProcessContext(component, data) as ProcessorsContext<ValidationScope>;
+    const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
     context.processors = [validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(0);
@@ -64,7 +64,7 @@ it('Should not validate a hidden component that has the hidden property set to t
     const component = hiddenRequiredField;
     component.hidden = true;
     const data = {};
-    const context = generateProcessContext(component, data) as ProcessorsContext<ValidationScope>;
+    const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
     context.processors = [validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(0);
@@ -79,7 +79,7 @@ it('Validating a simple component that is required but conditionally hidden', as
         eq: 'hideme'
     };
     const data = {otherData: 'hideme'};
-    const context = generateProcessContext(component, data) as ProcessorsContext<ValidationScope>;
+    const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
     context.processors = [validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(0);
@@ -90,7 +90,7 @@ it('Validating a simple component that is required but not persistent', async ()
     component.validate = { required: true };
     component.persistent = false;
     const data = {otherData: 'hideme'};
-    const context = generateProcessContext(component, data) as ProcessorsContext<ValidationScope>;
+    const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
     context.processors = [validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(0);
@@ -101,7 +101,7 @@ it('Validating a simple component that is required but persistent set to client-
     component.validate = { required: true };
     component.persistent = 'client-only';
     const data = {otherData: 'hideme'};
-    const context = generateProcessContext(component, data) as ProcessorsContext<ValidationScope>;
+    const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
     context.processors = [validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(0);
@@ -110,7 +110,7 @@ it('Validating a simple component that is required but persistent set to client-
 it('Should not validate a non input comonent', async () => {
     const component = requiredNonInputField;
     const data = {};
-    const context = generateProcessContext(component, data) as ProcessorsContext<ValidationScope>;
+    const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
     context.processors = [validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(0);
@@ -126,7 +126,7 @@ it('Should validate a conditionally hidden compoentn with validateWhenHidden fla
         eq: 'hideme'
     };
     const data = {otherData: 'hideme'};
-    const context = generateProcessContext(component, data) as ProcessorsContext<ValidationScope>;
+    const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
     context.processors = [validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(1);

--- a/src/process/validation/rules/__tests__/validateTime.test.ts
+++ b/src/process/validation/rules/__tests__/validateTime.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { TimeComponent } from 'types';
+import { FieldError } from 'error';
+
+import { generateProcessorContext } from './fixtures/util';
+import { validateTime } from '../validateTime';
+
+const timeField: TimeComponent = {
+    type: 'time',
+    key: 'time',
+    label: 'Time',
+    input: true,
+    dataFormat: 'HH:mm:ss'
+};
+
+it('Should validate a time component with a valid time value', async () => {
+    const data = { time: '12:00:00' };
+    const context = generateProcessorContext(timeField, data);
+    const result = await validateTime(context);
+    expect(result).to.equal(null);
+});
+
+it('Should return a FieldError when validating a time component with an invalid time value', async () => {
+    const data = { time: '25:00:00' };
+    const context = generateProcessorContext(timeField, data);
+    const result = await validateTime(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.contain('time');
+});
+
+it('Should return a FieldError when validating a time component with a valid format but one that does not match the dataFormat', async () => {
+    const data = { time: '12:00' };
+    const context = generateProcessorContext(timeField, data);
+    const result = await validateTime(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.contain('time');
+});
+
+it('Should return a FieldError when validating a time component with an invalid format', async () => {
+    const data = { time: '12:' };
+    const context = generateProcessorContext(timeField, data);
+    const result = await validateTime(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.contain('time');
+});

--- a/src/process/validation/rules/__tests__/validateUrl.test.ts
+++ b/src/process/validation/rules/__tests__/validateUrl.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { simpleUrlField } from './fixtures/components';
-import { generateProcessContext } from './fixtures/util';
+import { generateProcessorContext } from './fixtures/util';
 import { validateUrl } from '../validateUrl';
 
 it('Validating a URL component whose data contains an invalid URL returns a FieldError', async () => {
@@ -10,7 +10,7 @@ it('Validating a URL component whose data contains an invalid URL returns a Fiel
     const data = {
         component: 'htp:/ww.google',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateUrl(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('invalid_url');
@@ -21,7 +21,7 @@ it('Validating a URL component whose data contains an invalid URL returns a Fiel
     const data = {
         component: 'Hello, world!',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateUrl(context);
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain('invalid_url');
@@ -54,7 +54,7 @@ it('Validating a URL component whose data contains a valid HTTPS URL returns nul
     const data = {
         component: 'https://www.google.com',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateUrl(context);
     expect(result).to.equal(null);
 });
@@ -64,7 +64,7 @@ it('Validating a URL component whose data contains a valid HTTP URL returns null
     const data = {
         component: 'http://www.google.com',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateUrl(context);
     expect(result).to.equal(null);
 });
@@ -84,7 +84,7 @@ it('Validating a URL component whose data contains a strange but valid URL retur
     const data = {
         component: 'www.hhh.by',
     };
-    const context = generateProcessContext(component, data);
+    const context = generateProcessorContext(component, data);
     const result = await validateUrl(context);
     expect(result).to.equal(null);
 })

--- a/src/process/validation/rules/validateTime.ts
+++ b/src/process/validation/rules/validateTime.ts
@@ -4,6 +4,9 @@ import { isEmpty } from "../util";
 import { FieldError, ValidatorError } from 'error';
 import { dayjs } from 'utils/date';
 import { ProcessorInfo } from "types/process/ProcessorInfo";
+import customParsers from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParsers);
 
 const isValidatableTimeComponent = (comp: any): comp is TimeComponent => {
     return comp && comp.type === 'time';
@@ -28,7 +31,7 @@ export const validateTimeSync: RuleFnSync = (context: ValidationContext) => {
         const format = config?.server ?
             ((component as TimeComponent).dataFormat || 'HH:mm:ss') :
             ((component as TimeComponent).format || 'HH:mm');
-        const isValid = dayjs(String(value), format).isValid();
+        const isValid = dayjs(String(value), format, true).isValid();
         return isValid ? null : new FieldError('time', context);
     }
     catch (err) {

--- a/src/types/Component.ts
+++ b/src/types/Component.ts
@@ -494,7 +494,7 @@ export type TextAreaComponent = TextFieldComponent & {
 };
 
 export type TimeComponent = TextFieldComponent & {
-    format: string;
+    format?: string;
     dataFormat: string;
 };
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8079

## Description

This PR adds a normalization step that takes time components that are valid in the default time component `format` ("HH:mm") and coerces them into the `dataFormat` format (e.g. "HH:mm:ss"). Effectively, this will allow submissions that conform to either format while still validating correct times.

## Breaking Changes / Backwards Compatibility

It seems like we never really validated time components on the server (try submitting "10:0" or "10:" to a form with a time component via API on recent release branches), so there may be a risk that customers that are used to the status quo of no validation may run into problems. Additionally, the new stricter validation scheme will also reject invalid times that are in the correct format (e.g. "25:00:00"), which previously might have been parsed as "24 hours + 1 hour into the next day." 

## Dependencies

n/a

## How has this PR been tested?

manually and added automated tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
