### PR TITLE
FIO-8086: don't multiple validate select components

### DIFF
--- a/src/process/validation/rules/__tests__/validateMultiple.test.ts
+++ b/src/process/validation/rules/__tests__/validateMultiple.test.ts
@@ -192,7 +192,8 @@ describe('validateMultiple', () => {
 
     describe('validateMultipleSync', () => {
         describe('values that should be arrays', () => {
-            it('should return an error for a select component with multiple that is not an array', () => {
+            // TODO: skipping the following tests until we can resolve whether or not we want to validateMultiple on select components
+            xit('should return an error for a select component with multiple that is not an array', () => {
                 const component: Component = {
                     type: 'select',
                     input: true,
@@ -216,7 +217,7 @@ describe('validateMultiple', () => {
                 expect(validateMultipleSync(context)).to.be.instanceOf(FieldError);
             });
 
-            it('should return null for a select component with multiple that is an array', () => {
+            xit('should return null for a select component with multiple that is an array', () => {
                 const component: Component = {
                     type: 'select',
                     input: true,
@@ -240,7 +241,7 @@ describe('validateMultiple', () => {
                 expect(validateMultipleSync(context)).to.be.null;
             });
 
-            it('should return an error for a select component without multiple that is an array', () => {
+            xit('should return an error for a select component without multiple that is an array', () => {
                 const component: Component = {
                     type: 'select',
                     input: true,
@@ -263,7 +264,7 @@ describe('validateMultiple', () => {
                 expect(validateMultipleSync(context)).to.be.instanceOf(FieldError);
             });
 
-            it('should return null for a select component without multiple that is not an array', () => {
+            xit('should return null for a select component without multiple that is not an array', () => {
                 const component: Component = {
                     type: 'select',
                     input: true,
@@ -277,6 +278,30 @@ describe('validateMultiple', () => {
                     value: 'foo',
                     row: {
                         select: 'foo'
+                    },
+                    scope: {
+                        errors: []
+                    },
+                    path: component.key
+                };
+                expect(validateMultipleSync(context)).to.be.null;
+            });
+
+            it('should not validate a select component with multiple', () => {
+                const component: Component = {
+                    type: 'select',
+                    input: true,
+                    key: 'select',
+                    multiple: true,
+                };
+                const context: ValidationContext = {
+                    component,
+                    data: {
+                        select: ['foo', 'bar'],
+                    },
+                    value: ['foo', 'bar'],
+                    row: {
+                        select: ['foo', 'bar'],
                     },
                     scope: {
                         errors: []

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -17,6 +17,10 @@ export const isEligible = (component: Component) => {
                 return false;
             }
             return true;
+        // TODO: For backwards compatibility, skip multiple validation for select components until we can investigate
+        // how this validation might break existing forms
+        case 'select':
+            return false;
         default:
             return true;
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8086

## Description

The [core library](https://github.com/formio/core/blob/6129877811e005ec1a8ca54e722db68ab9e241c6/src/process/validation/rules/validateMultiple.ts) (and, previously, the [JavaScript renderer](https://github.com/formio/formio.js/blob/faf72202df5ce74ec698637444f4c7f7674a0568/src/validator/Validator.js#L205)) have a data model validation rule which checks various components against their submission data type. For example, a text field with "Multiple Values" enabled will be expected to have a submission that is an array, whereas we wouldn't expect an array for a Date / Time picker. 

However, it seems that Select components [skipped](https://github.com/formio/formio.js/blob/faf72202df5ce74ec698637444f4c7f7674a0568/src/components/select/Select.js#L1698) this [type of validation](https://github.com/formio/formio.js/blob/faf72202df5ce74ec698637444f4c7f7674a0568/src/validator/Validator.js#L220) for reasons that are unclear to me. When implementing the new validation system, I had thought that this was an oversight, especially because references to select components are made further down the validation pipeline. However, this caused the above regression, so for backwards compatibility we're once again skipping this type of validation for select components.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I've removed (by using the `xit` mocha method) tests that covered `validateMultiple` around select components and added a (temporary?) test that ensures that select components are not validated until we can resolve the ambiguity around this issue.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
