### PR TITLE
FIO-8092: update isEmpty to isComponentDataEmpty and account for differing component data types

### DIFF
--- a/src/process/validation/rules/validateTime.ts
+++ b/src/process/validation/rules/validateTime.ts
@@ -1,6 +1,6 @@
 
 import { RuleFn, RuleFnSync, TimeComponent, ValidationContext } from "types";
-import { isEmpty } from "../util";
+import { isComponentDataEmpty } from 'utils/formUtil';
 import { FieldError, ValidatorError } from 'error';
 import { dayjs } from 'utils/date';
 import { ProcessorInfo } from "types/process/ProcessorInfo";
@@ -21,12 +21,12 @@ export const shouldValidate = (context: ValidationContext) => {
 };
 
 export const validateTimeSync: RuleFnSync = (context: ValidationContext) => {
-    const { component, value, config } = context;
+    const { component, data, path, value, config } = context;
     if (!shouldValidate(context)) {
         return null;
     }
     try {
-        if (!value || isEmpty(component, value)) return null;
+        if (!value || isComponentDataEmpty(component, data, path)) return null;
         // Server side evaluations of validity should use the "dataFormat" vs the "format" which is used on the client.
         const format = config?.server ?
             ((component as TimeComponent).dataFormat || 'HH:mm:ss') :

--- a/src/process/validation/util.ts
+++ b/src/process/validation/util.ts
@@ -1,8 +1,9 @@
 import { FieldError } from 'error';
-import { isArray, isEqual } from 'lodash';
-import { Component, ValidationContext } from 'types';
+import { isArray, isEqual, get } from 'lodash';
+import { CheckboxComponent, Component, DataGridComponent, DataTableComponent, DateTimeComponent, EditGridComponent, HasChildComponents, SelectBoxesComponent, TextAreaComponent, TextFieldComponent, ValidationContext } from 'types';
 import { Evaluator, unescapeHTML } from 'utils';
 import { VALIDATION_ERRORS } from './i18n';
+import { eachComponentData } from 'utils/formUtil.js';
 
 export function isComponentPersistent(component: Component) {
     return component.persistent ? component.persistent : true;
@@ -51,28 +52,6 @@ export function isObject(obj: any): obj is Object {
     return typeof obj != null && (typeof obj === 'object' || typeof obj === 'function');
 }
 
-export function getEmptyValue(component: Component) {
-    switch (component.type) {
-        case 'textarea':
-        case 'textfield':
-        case 'time':
-        case 'datetime':
-        case 'day':
-            return '';
-        case 'datagrid':
-        case 'editgrid':
-            return [];
-
-        default:
-            return null;
-    }
-}
-
-export function isEmpty(component: Component, value: unknown) {
-    const isEmptyArray = (isArray(value) && value.length === 1) ? isEqual(value[0], getEmptyValue(component)) : false;
-    return value == null || (isArray(value) && value.length === 0) || isEmptyArray;
-}
-
 /**
  * Interpolates @formio/core errors so that they are compatible with the renderer
  * @param {FieldError[]} errors
@@ -95,7 +74,7 @@ export const interpolateErrors = (errors: FieldError[], lang: string = 'en') => 
                 paths.push(part);
             }
         });
-        return { 
+        return {
             message: unescapeHTML(Evaluator.interpolateString(toInterpolate, context)),
             level: error.level,
             path: paths,

--- a/src/process/validation/util.ts
+++ b/src/process/validation/util.ts
@@ -1,9 +1,7 @@
 import { FieldError } from 'error';
-import { isArray, isEqual, get } from 'lodash';
-import { CheckboxComponent, Component, DataGridComponent, DataTableComponent, DateTimeComponent, EditGridComponent, HasChildComponents, SelectBoxesComponent, TextAreaComponent, TextFieldComponent, ValidationContext } from 'types';
+import { Component, ValidationContext } from 'types';
 import { Evaluator, unescapeHTML } from 'utils';
 import { VALIDATION_ERRORS } from './i18n';
-import { eachComponentData } from 'utils/formUtil.js';
 
 export function isComponentPersistent(component: Component) {
     return component.persistent ? component.persistent : true;

--- a/src/types/Component.ts
+++ b/src/types/Component.ts
@@ -86,6 +86,10 @@ export type ContainerComponent = NestedComponent & {
     components: Component[];
 };
 
+export type HasChildComponents = BaseComponent & {
+    components: Component[];
+}
+
 export type AddressComponent = ContainerComponent & {
     switchToManualModeLabel: string;
     provider: string;
@@ -140,6 +144,7 @@ export type NumberComponent = BaseComponent & {
 
 export type NestedArrayComponent = NestedComponent & {
     disableAddingRemovingRows: boolean;
+    components: Component[];
 };
 
 export type DataGridComponent = NestedArrayComponent;

--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import { getContextualRowData, eachComponentDataAsync, isComponentDataEmpty } from "../formUtil";
 
-xdescribe('getContextualRowData', () => {
+describe('getContextualRowData', () => {
     it('Should return the data at path without the last element given nested containers', () => {
         const data = {
             a: {
@@ -233,7 +233,7 @@ xdescribe('getContextualRowData', () => {
     });
 });
 
-xdescribe('eachComponentDataAsync', () => {
+describe('eachComponentDataAsync', () => {
     describe('Flattened form components (for evaluation)', () => {
         it('Should return the correct contextual row data for each component', async () => {
             const components = [

--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 
-import { getContextualRowData, eachComponentDataAsync } from "../formUtil";
+import { getContextualRowData, eachComponentDataAsync, isComponentDataEmpty } from "../formUtil";
 
-describe('getContextualRowData', () => {
+xdescribe('getContextualRowData', () => {
     it('Should return the data at path without the last element given nested containers', () => {
         const data = {
             a: {
@@ -15,7 +15,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
            type: 'textfield',
            input: true,
-           key: 'c' 
+           key: 'c'
         }, path, data);
         const expected = { c: 'hello' };
         expect(actual).to.deep.equal(expected);
@@ -33,7 +33,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'b' 
+            key: 'b'
          }, path, data);
         const expected = { b: { c: 'hello' } };
         expect(actual).to.deep.equal(expected);
@@ -51,7 +51,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'a' 
+            key: 'a'
          }, path, data);
         const expected = { a: { b: { c: 'hello' } } };
         expect(actual).to.deep.equal(expected);
@@ -70,7 +70,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'd' 
+            key: 'd'
          }, path, data);
         const expected = { a: { b: { c: 'hello' } }, d: 'there' };
         expect(actual).to.deep.equal(expected);
@@ -84,7 +84,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'b' 
+            key: 'b'
          }, path, data);
         const expected = {b: 'hello', c: 'world'};
         expect(actual).to.deep.equal(expected);
@@ -98,7 +98,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'b' 
+            key: 'b'
          }, path, data);
         const expected = {b: 'foo', c: 'bar'};
         expect(actual).to.deep.equal(expected);
@@ -112,7 +112,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'a' 
+            key: 'a'
          }, path, data);
         const expected = {
             a: [{b: 'hello', c: 'world'}, {b: 'foo', c: 'bar'}],
@@ -128,7 +128,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'a' 
+            key: 'a'
          }, path, data);
         const expected = {
             a: [{b: 'hello', c: 'world'}, {b: 'foo', c: 'bar'}],
@@ -146,7 +146,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'c' 
+            key: 'c'
          }, path, data);
         const expected = {c: 'hello', d: 'world'};
         expect(actual).to.deep.equal(expected);
@@ -162,7 +162,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'c' 
+            key: 'c'
          }, path, data);
         const expected = {c: 'foo', d: 'bar'};
         expect(actual).to.deep.equal(expected);
@@ -178,7 +178,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'b' 
+            key: 'b'
          }, path, data);
         const expected = {b: [{c: 'hello', d: 'world'}, {c: 'foo', d: 'bar'}]};
         expect(actual).to.deep.equal(expected);
@@ -194,7 +194,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'a' 
+            key: 'a'
          }, path, data);
         const expected = {a: {b: [{c: 'hello', d: 'world'}, {c: 'foo', d: 'bar'}]}};
         expect(actual).to.deep.equal(expected);
@@ -210,7 +210,7 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'a' 
+            key: 'a'
          }, path, data);
         const expected = {a: {b: [{c: 'hello', d: 'world'}, {c: 'foo', d: 'bar'}]}};
         expect(actual).to.deep.equal(expected);
@@ -226,14 +226,14 @@ describe('getContextualRowData', () => {
         const actual = getContextualRowData({
             type: 'textfield',
             input: true,
-            key: 'c.e' 
+            key: 'c.e'
          }, path, data);
         const expected = {c: {e: 'zed'}, d: 'world'};
         expect(actual).to.deep.equal(expected);
     });
 });
 
-describe('eachComponentDataAsync', () => {
+xdescribe('eachComponentDataAsync', () => {
     describe('Flattened form components (for evaluation)', () => {
         it('Should return the correct contextual row data for each component', async () => {
             const components = [
@@ -362,5 +362,346 @@ describe('eachComponentDataAsync', () => {
             });
             console.log(rowResults);
         });
+    });
+});
+
+describe('isEmpty', () => {
+    it('Should return true for an empty object', () => {
+        const component = {
+            type: 'textfield',
+            input: true,
+            key: 'textField',
+        };
+        const data = {};
+        const actual = isComponentDataEmpty(component, data, 'textField');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return false for a non-empty object', () => {
+        const component = {
+            type: 'textfield',
+            input: true,
+            key: 'textField',
+        };
+        const data = {
+            textField: 'hello',
+        };
+        const actual = isComponentDataEmpty(component, data, 'textField');
+        const expected = false;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for a checkbox component set to false', () => {
+        const component = {
+            type: 'checkbox',
+            input: true,
+            key: 'checkbox',
+        };
+        const data = {
+            checkbox: false,
+        };
+        const actual = isComponentDataEmpty(component, data, 'checkbox');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return false for a checkbox component set to true', () => {
+        const component = {
+            type: 'checkbox',
+            input: true,
+            key: 'checkbox',
+        };
+        const data = {
+            checkbox: true,
+        };
+        const actual = isComponentDataEmpty(component, data, 'checkbox');
+        const expected = false;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for an empty dataGrid component', () => {
+        const component = {
+            type: 'datagrid',
+            input: true,
+            key: 'dataGrid',
+        };
+        const data = {
+            dataGrid: [],
+        };
+        const actual = isComponentDataEmpty(component, data, 'dataGrid');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for a non-empty dataGrid component with empty child components', () => {
+        const component = {
+            type: 'datagrid',
+            input: true,
+            key: 'dataGrid',
+            components: [
+                {
+                    type: 'textfield',
+                    input: true,
+                    key: 'textField',
+                },
+                {
+                    type: 'checkbox',
+                    input: true,
+                    key: 'checkbox'
+                },
+                {
+                    type: 'textarea',
+                    wysiwyg: true,
+                    input: true,
+                    key: 'textArea'
+                }
+            ],
+        };
+        const data = {
+            dataGrid: [
+                {
+                    textField: '',
+                    checkbox: false,
+                    textArea: '<p>&nbsp;</p>',
+                },
+            ],
+        };
+        const actual = isComponentDataEmpty(component, data, 'dataGrid');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return false for a datagrid with non-empty child components', () => {
+        const component = {
+            type: 'datagrid',
+            input: true,
+            key: 'dataGrid',
+            components: [
+                {
+                    type: 'textfield',
+                    input: true,
+                    key: 'textField',
+                },
+                {
+                    type: 'checkbox',
+                    input: true,
+                    key: 'checkbox'
+                },
+                {
+                    type: 'textarea',
+                    wysiwyg: true,
+                    input: true,
+                    key: 'textArea'
+                }
+            ],
+        };
+        const data = {
+            dataGrid: [
+                {
+                    textField: 'hello',
+                    checkbox: true,
+                    textArea: '<p>world</p>',
+                },
+            ],
+        };
+        const actual = isComponentDataEmpty(component, data, 'dataGrid');
+        const expected = false;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for an empty Select Boxes component', () => {
+        const component = {
+            type: 'selectboxes',
+            input: true,
+            key: 'selectBoxes',
+            data: {
+                values: [
+                    {
+                        label: 'foo',
+                        value: 'foo',
+                    },
+                    {
+                        label: 'bar',
+                        value: 'bar',
+                    },
+                ],
+            },
+        };
+        const data = {
+            selectBoxes: {},
+        };
+        const actual = isComponentDataEmpty(component, data, 'selectBoxes');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for a non-empty Select Boxes component with no selected values', () => {
+        const component = {
+            type: 'selectboxes',
+            input: true,
+            key: 'selectBoxes',
+            data: {
+                values: [
+                    {
+                        label: 'foo',
+                        value: 'foo',
+                    },
+                    {
+                        label: 'bar',
+                        value: 'bar',
+                    },
+                ],
+            },
+        };
+        const data = {
+            selectBoxes: {
+                foo: false,
+                bar: false,
+            },
+        };
+        const actual = isComponentDataEmpty(component, data, 'selectBoxes');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return false for a non-empty Select Boxes component with selected values', () => {
+        const component = {
+            type: 'selectboxes',
+            input: true,
+            key: 'selectBoxes',
+            data: {
+                values: [
+                    {
+                        label: 'foo',
+                        value: 'foo',
+                    },
+                    {
+                        label: 'bar',
+                        value: 'bar',
+                    },
+                ],
+            },
+        };
+        const data = {
+            selectBoxes: {
+                foo: true,
+                bar: false,
+            },
+        };
+        const actual = isComponentDataEmpty(component, data, 'selectBoxes');
+        const expected = false;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for an empty Select component', () => {
+        const component = {
+            type: 'select',
+            input: true,
+            key: 'select',
+            data: {
+                values: [
+                    {
+                        label: 'foo',
+                        value: 'foo',
+                    },
+                    {
+                        label: 'bar',
+                        value: 'bar',
+                    },
+                ],
+            },
+        };
+        const data = {
+            select: '',
+        };
+        const actual = isComponentDataEmpty(component, data, 'select');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for an empty plain Text Area component', () => {
+        const component = {
+            type: 'textarea',
+            input: true,
+            key: 'textArea',
+        };
+        const data = {
+            textArea: '',
+        };
+        const actual = isComponentDataEmpty(component, data, 'textArea');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for a non-empty non-plain Text Area component with only WYSIWYG or editor HTML', () => {
+        const component = {
+            type: 'textarea',
+            input: true,
+            key: 'textArea',
+            wysiwyg: true
+        };
+        const data = {
+            textArea: '<p>&nbsp;</p>',
+        };
+        const actual = isComponentDataEmpty(component, data, 'textArea');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for a non-empty text area with only whitespace', () => {
+        const component = {
+            type: 'textarea',
+            input: true,
+            key: 'textArea',
+        };
+        const data = {
+            textArea: '   ',
+        };
+        const actual = isComponentDataEmpty(component, data, 'textArea');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return false for a non-empty Text Field', () => {
+        const component = {
+            type: 'textfield',
+            input: true,
+            key: 'textField',
+        };
+        const data = {
+            textField: 'hello',
+        };
+        const actual = isComponentDataEmpty(component, data, 'textField');
+        const expected = false;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for an empty Text Field component', () => {
+        const component = {
+            type: 'textfield',
+            input: true,
+            key: 'textField',
+        };
+        const data = {
+            textField: '',
+        };
+        const actual = isComponentDataEmpty(component, data, 'textField');
+        const expected = true;
+        expect(actual).to.equal(expected);
+    });
+
+    it('Should return true for a non-empty Text Field component with only whitespace', () => {
+        const component = {
+            type: 'textfield',
+            input: true,
+            key: 'textField',
+        };
+        const data = {
+            textField: '   ',
+        };
+        const actual = isComponentDataEmpty(component, data, 'textField');
+        const expected = true;
+        expect(actual).to.equal(expected);
     });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -81,7 +81,7 @@ export function formatDate(value: any, format: any, timezone: any): string {
  * @param date
  * @return {(null|Date)}
  */
- export function getDateSetting(date: any) {
+export function getDateSetting(date: any) {
     if (isNil(date) || isNaN(date) || date === '') {
       return null;
     }
@@ -125,9 +125,9 @@ export function formatDate(value: any, format: any, timezone: any): string {
     }
 
     return dateSetting.toDate();
-  }
+}
 
-  export const getDateValidationFormat = (component: DayComponent) => {
+export const getDateValidationFormat = (component: DayComponent) => {
     return component.dayFirst ? 'DD-MM-YYYY' : 'MM-DD-YYYY';
 };
 

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -1112,6 +1112,8 @@ export function isComponentDataEmpty(component: Component, data: any, path: stri
     } else if (isDataGridComponent(component) || isEditGridComponent(component) || isDataTableComponent(component) || hasChildComponents(component)) {
         if (component.components?.length) {
             let childrenEmpty = true;
+            // TODO: eachComponentData currently can't handle passing child components directly because it won't get the path right;
+            // wrapping component in an array and skipping it's callback is a workaround to start with the correct path, but it is not ideal
             eachComponentData([component], data, (thisComponent, data, row, path, components, index) => {
                 if (component.key === thisComponent.key) return;
                 if (!isComponentDataEmpty(thisComponent, data, path)) {

--- a/src/utils/operators/DateGreaterThan.js
+++ b/src/utils/operators/DateGreaterThan.js
@@ -1,5 +1,6 @@
 import ConditionOperator from './ConditionOperator';
 import moment from 'moment';
+import { isPartialDay, getDateValidationFormat } from '../../utils/date';
 export default class DateGeaterThan extends ConditionOperator {
     static get operatorKey() {
         return 'dateGreaterThan';
@@ -10,7 +11,7 @@ export default class DateGeaterThan extends ConditionOperator {
     }
 
     getFormattedDates({ value, comparedValue, conditionTriggerComponent }) {
-        const hasValidationFormat = conditionTriggerComponent ? conditionTriggerComponent.getValidationFormat : null;
+        const hasValidationFormat = conditionTriggerComponent && conditionTriggerComponent.component.type === 'day' ? getDateValidationFormat(conditionTriggerComponent.component) : null;
         const date = hasValidationFormat ? moment(value, conditionTriggerComponent.getValidationFormat()) : moment(value);
         const comparedDate = hasValidationFormat ? moment(comparedValue, conditionTriggerComponent.getValidationFormat()) : moment(comparedValue);
 
@@ -30,7 +31,7 @@ export default class DateGeaterThan extends ConditionOperator {
             conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
         }
 
-        if ( conditionTriggerComponent && conditionTriggerComponent.isPartialDay && conditionTriggerComponent.isPartialDay(value)) {
+        if (conditionTriggerComponent && conditionTriggerComponent.component.type === 'day' && isPartialDay(conditionTriggerComponent.component, value)) {
             return false;
         }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8092

## Description

This PR more fully adopts component-specific `isEmpty()` logic from the formio.js renderer to FormUtils so that we can be sure things like [logical operators](https://github.com/formio/core/blob/ddba72c1cf085fd1ab2faa0850e4be9a05eadc68/src/utils/operators/IsEmptyValue.js#L22) work as expected. It also converts instance shim calls to `getValidationFormat` and `isPartialDay` for day components to preexisting utility functions in the core library.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Added automated tests around `isEmpty`. 

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
