### PR TITLE
FIO-8100: add clearhidden processor to cover logic, conditions, and custom

### DIFF
--- a/src/process/clearHidden.ts
+++ b/src/process/clearHidden.ts
@@ -6,17 +6,24 @@ import {
     ProcessorFnSync
 } from "types";
 
-/**
- * This processor function checks components for the `hidden` property and unsets corresponding data
- */
-export const clearHiddenProcess: ProcessorFnSync<ProcessorScope> = (context) => {
-    const { component, data, path, value } = context;
-    if (component.hidden && value !== undefined && (!component.hasOwnProperty('clearOnHide') || component.clearOnHide)) {
-        unset(data, path);
+type ClearHiddenScope = ProcessorScope & {
+    clearHidden: {
+        [path: string]: boolean;
     }
 }
 
-export const clearHiddenProcessInfo: ProcessorInfo<ProcessorContext<ProcessorScope>, void> = {
+/**
+ * This processor function checks components for the `hidden` property and unsets corresponding data
+ */
+export const clearHiddenProcess: ProcessorFnSync<ClearHiddenScope> = (context) => {
+    const { component, data, path, value, scope } = context;
+    if (component.hidden && value !== undefined && (!component.hasOwnProperty('clearOnHide') || component.clearOnHide)) {
+        unset(data, path);
+        scope.clearHidden[path] = true;
+    }
+}
+
+export const clearHiddenProcessInfo: ProcessorInfo<ProcessorContext<ClearHiddenScope>, void> = {
     name: 'clearHidden',
     shouldProcess: () => true,
     processSync: clearHiddenProcess,

--- a/src/process/clearHidden.ts
+++ b/src/process/clearHidden.ts
@@ -1,0 +1,23 @@
+import unset from 'lodash/unset';
+import {
+    ProcessorScope,
+    ProcessorContext,
+    ProcessorInfo,
+    ProcessorFnSync
+} from "types";
+
+/**
+ * This processor function checks components for the `hidden` property and unsets corresponding data
+ */
+export const clearHiddenProcess: ProcessorFnSync<ProcessorScope> = (context) => {
+    const { component, data, path, value } = context;
+    if (component.hidden && value !== undefined && (!component.hasOwnProperty('clearOnHide') || component.clearOnHide)) {
+        unset(data, path);
+    }
+}
+
+export const clearHiddenProcessInfo: ProcessorInfo<ProcessorContext<ProcessorScope>, void> = {
+    name: 'clearHidden',
+    shouldProcess: () => true,
+    processSync: clearHiddenProcess,
+}

--- a/src/process/clearHidden.ts
+++ b/src/process/clearHidden.ts
@@ -17,6 +17,9 @@ type ClearHiddenScope = ProcessorScope & {
  */
 export const clearHiddenProcess: ProcessorFnSync<ClearHiddenScope> = (context) => {
     const { component, data, path, value, scope } = context;
+    if (!scope.clearHidden) {
+        scope.clearHidden = {};
+    }
     if (component.hidden && value !== undefined && (!component.hasOwnProperty('clearOnHide') || component.clearOnHide)) {
         unset(data, path);
         scope.clearHidden[path] = true;

--- a/src/process/conditions/__tests__/conditions.test.ts
+++ b/src/process/conditions/__tests__/conditions.test.ts
@@ -1,44 +1,54 @@
 import { expect } from 'chai';
-import { process } from '../../process'
+import { processSync } from '../../process'
 import { conditionProcessInfo } from '../index';
 import { ConditionsScope, ProcessContext } from 'types';
 
-const processForm = async (form: any, submission: any) => {
+const processForm = (form: any, submission: any) => {
     const context: ProcessContext<ConditionsScope> = {
         processors: [conditionProcessInfo],
         components: form.components,
         data: submission.data,
         scope: {}
     };
-    await process(context);
+    processSync(context);
     return context;
 };
 
 describe('Condition processor', () => {
-    it('Perform conditional data with "clearOnHide" enabled.', async () => {
+    it('Should modify component\'s "hidden" property when conditionally visible is false', async () => {
         const form = {
             components: [
                 {
-                    type: 'number',
+                    type: 'textfield',
                     key: 'a',
                     input: true
                 },
                 {
-                    type: 'number',
+                    type: 'textfield',
                     key: 'b',
-                    input: true
+                    input: true,
+                    conditional: {
+                        show: false,
+                        conjunction: 'all',
+                        conditions: [
+                          {
+                            component: 'a',
+                            operator: 'isEmpty'
+                          }
+                        ]
+                      },
                 }
             ]
         };
-    
+
         const submission = {
             data: {
-                a: 1,
-                b: 2
+                a: '',
             }
         };
-    
-        const context: ProcessContext<ConditionsScope> = await processForm(form, submission);
-        console.log(context);
+
+        const context: ProcessContext<ConditionsScope> = processForm(form, submission);
+        expect(context.components[1]).to.haveOwnProperty('hidden');
+        expect(context.components[1].hidden).to.be.true;
     });
 });

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -1,6 +1,6 @@
 import { ProcessorFn, ProcessorFnSync, ConditionsScope, ProcessorInfo, ConditionsContext, SimpleConditional, JSONConditional, LegacyConditional, SimpleConditionalConditions, Component, NestedComponent, FilterScope } from 'types';
 import { Utils } from 'utils';
-import unset from 'lodash/unset';
+import set from 'lodash/set';
 import { componentInfo, getComponentKey, getComponentPath } from 'utils/formUtil';
 import {
     checkCustomConditional,
@@ -112,16 +112,12 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
             Utils.eachComponentData([component], row, (comp: Component, data: any, compRow: any, compPath: string) => {
                 if (comp !== component) {
                     scope.conditionals?.push({ path: getComponentPath(comp, compPath), conditionallyHidden: true });
-                } 
-                if (!comp.hasOwnProperty('clearOnHide') || comp.clearOnHide) {
-                    unset(compRow, getComponentKey(comp));
                 }
+                set(comp, 'hidden', true);
             });
         }
         else {
-            if (!component.hasOwnProperty('clearOnHide') || component.clearOnHide) {
-                unset(data, path);
-            }
+            set(component, 'hidden', true);
         }
     } else {
         conditionalComp.conditionallyHidden = false;

--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -12,6 +12,7 @@ import { validateCustomProcessInfo, validateProcessInfo, validateServerProcessIn
 import { filterProcessInfo } from "./filter";
 import { normalizeProcessInfo } from "./normalize";
 import { dereferenceProcessInfo } from "./dereference";
+import { clearHiddenProcessInfo } from "./clearHidden";
 
 export async function process<ProcessScope>(context: ProcessContext<ProcessScope>): Promise<ProcessScope> {
     const { instances, components, data, scope, flat, processors } = context;
@@ -91,6 +92,7 @@ export const ProcessorMap: Record<string, ProcessorInfo<any, any>> = {
     simpleConditions: simpleConditionProcessInfo,
     normalize: normalizeProcessInfo,
     dereference: dereferenceProcessInfo,
+    clearHidden: clearHiddenProcessInfo,
     fetch: fetchProcessInfo,
     logic: logicProcessInfo,
     validate: validateProcessInfo,
@@ -113,6 +115,7 @@ export const ProcessTargets: ProcessTarget = {
         calculateProcessInfo,
         logicProcessInfo,
         conditionProcessInfo,
+        clearHiddenProcessInfo,
         validateProcessInfo
     ]
 };

--- a/src/types/BaseComponent.ts
+++ b/src/types/BaseComponent.ts
@@ -3,7 +3,7 @@ import { AdvancedLogic } from "./AdvancedLogic";
 
 export type JSONConditional = { json: RulesLogic; };
 export type LegacyConditional = { show: boolean | string | null; when: string | null; eq: boolean | string };
-export type SimpleConditionalConditions = { component: string; operator: string; value: any}[];
+export type SimpleConditionalConditions = { component: string; operator: string; value?: any}[];
 export type SimpleConditional = { show: boolean | null; conjunction: string; conditions: SimpleConditionalConditions};
 
 export type BaseComponent = {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8100

## Description

The `conditionals` processor originally cleared submission data properties for components that were conditionally hidden. However, this fails to account for other ways a component might be hidden, such as Advanced Logic or custom logic within the component. This PR changes the `conditionals` processor to merely set `hidden` to true on the component and adds a `clearHidden` processor that is responsible for unsetting any submission data tied to hidden components.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Automated + manual

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
