### PR TITLE
FIO-8101: always process json validation even if value is falsy

### DIFF
--- a/src/process/validation/rules/__tests__/validateJson.test.ts
+++ b/src/process/validation/rules/__tests__/validateJson.test.ts
@@ -71,3 +71,32 @@ it('A simple component with JSON logic evaluation will return null if the JSON l
     const result = await validateJson(context);
     expect(result).to.equal(null);
 });
+
+it('A simple component with JSON logic evaluation will validate even if the value is falsy', async () => {
+    const component = {
+        ...simpleTextField,
+        validate: {
+            json: {
+                if: [
+                    {
+                        '===': [
+                            {
+                                var: 'input',
+                            },
+                            'foo',
+                        ],
+                    },
+                    true,
+                    "Input must be 'foo'",
+                ],
+            },
+        },
+    };
+    const data = {
+        component: '',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateJson(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.contain("Input must be 'foo'");
+});

--- a/src/process/validation/rules/validateJson.ts
+++ b/src/process/validation/rules/validateJson.ts
@@ -6,7 +6,7 @@ import { isObject } from 'lodash';
 
 export const shouldValidate = (context: ValidationContext) => {
     const { component, value } = context;
-    if (!value || !component.validate?.json || !isObject(component.validate.json)) {
+    if (!component.validate?.json || !isObject(component.validate.json)) {
         return false;
     }
     return true;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8101

## Description

We need to evaluate custom JSON logic validations even if the value is falsy.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Added an automated test case

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
