### PR TITLE
Fix: JSONLogic validations should get same context as calculations

### DIFF
--- a/src/process/validation/rules/__tests__/fixtures/util.ts
+++ b/src/process/validation/rules/__tests__/fixtures/util.ts
@@ -1,12 +1,13 @@
 import { get } from "lodash";
-import { Component, DataObject, ProcessorType, ValidationContext } from "types";
+import { Component, DataObject, Form, ProcessorType, ValidationContext } from "types";
 
-export const generateProcessorContext = (component: Component, data: DataObject): ValidationContext => {
+export const generateProcessorContext = (component: Component, data: DataObject, form?: any): ValidationContext => {
     const path = component.key;
     const value = get(data, path);
     return {
         component,
         data,
+        form,
         scope: {errors: []},
         row: data,
         path: component.key,

--- a/src/process/validation/rules/__tests__/validateJson.test.ts
+++ b/src/process/validation/rules/__tests__/validateJson.test.ts
@@ -100,3 +100,35 @@ it('A simple component with JSON logic evaluation will validate even if the valu
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.contain("Input must be 'foo'");
 });
+
+it('Should have access to form JSON in its validation context', async () => {
+    const component = {
+        ...simpleTextField,
+        validate: {
+            json: {
+                if: [
+                    {
+                        '>': [
+                            {
+                                var: 'form.components',
+                            },
+                            5,
+                        ],
+                    },
+                    true,
+                    'Form must have greater than 5 components',
+                ],
+            },
+        },
+    };
+    const form = {
+        components: [component],
+    }
+    const data = {
+        component: 'foo',
+    };
+    const context = generateProcessorContext(component, data, form);
+    const result = await validateJson(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.contain("Form must have greater than 5 components");
+})

--- a/src/process/validation/rules/validateJson.ts
+++ b/src/process/validation/rules/validateJson.ts
@@ -5,7 +5,7 @@ import { ProcessorInfo } from 'types/process/ProcessorInfo';
 import { isObject } from 'lodash';
 
 export const shouldValidate = (context: ValidationContext) => {
-    const { component, value } = context;
+    const { component } = context;
     if (!component.validate?.json || !isObject(component.validate.json)) {
         return false;
     }
@@ -17,18 +17,17 @@ export const validateJson: RuleFn = async (context: ValidationContext) => {
 };
 
 export const validateJsonSync: RuleFnSync = (context: ValidationContext) => {
-    const { component, data, value } = context;
+    const { component, data, value, evalContext } = context;
     if (!shouldValidate(context)) {
         return null;
     }
 
     const func = component?.validate?.json;
+    const evalContextValue = evalContext ? evalContext(context) : context;
+    evalContextValue.value = value || null;
     const valid: true | string = jsonLogic.evaluator.evaluate(
         func,
-        {
-            data,
-            input: value,
-        },
+        evalContextValue,
         'valid'
     );
     if (valid === null) {

--- a/src/process/validation/rules/validateJson.ts
+++ b/src/process/validation/rules/validateJson.ts
@@ -27,7 +27,10 @@ export const validateJsonSync: RuleFnSync = (context: ValidationContext) => {
     evalContextValue.value = value || null;
     const valid: true | string = jsonLogic.evaluator.evaluate(
         func,
-        evalContextValue,
+        {
+            ...evalContextValue,
+            input: value,
+        },
         'valid'
     );
     if (valid === null) {


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

In fixing another blocker ticket, we came across the fact that JSONLogic validations were not receiving a full context object. This PR fixes that issue.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

manually plus an automated test

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
