### PR TITLE
FIO-8128: allow export of dist minified js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "./sdk": "./lib/sdk/index.js",
     "./process": "./lib/process/index.js",
     "./types": "./lib/types/index.js",
-    "./experimental": "./lib/experimental/index.js"
+    "./experimental": "./lib/experimental/index.js",
+    "./dist/formio.core.min.js": "./dist/formio.core.min.js"
   },
   "scripts": {
     "test": "TEST=1 mocha -r ts-node/register -r tsconfig-paths/register -r mock-local-storage -r jsdom-global/register -b -t 0 'src/**/__tests__/*.test.ts'",


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8128

## Description

We've decided that the caller of `evaluateProcess` should be able to inject dependencies at the call site. This PR will allow libraries like `formio` and `formio-server` to easily read the contents of the minified core JS file into memory and inject that dependency into the vm's evaluation context.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
