### PR TITLE
FIO-8143: update eachComponent to be able to return proper pathing

### DIFF
--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -201,6 +201,9 @@ export const componentChildPath = (component: any, parentPath?: string, path?: s
     if (isComponentModelType(component, 'dataObject')) {
       return `${path}.data`;
     }
+    if (isComponentModelType(component, 'array')) {
+      return `${path}[0]`;
+    }
     if (isComponentNestedDataType(component)) {
       return path;
     }
@@ -1112,8 +1115,8 @@ export function isComponentDataEmpty(component: Component, data: any, path: stri
     } else if (isDataGridComponent(component) || isEditGridComponent(component) || isDataTableComponent(component) || hasChildComponents(component)) {
         if (component.components?.length) {
             let childrenEmpty = true;
-            // TODO: eachComponentData currently can't handle passing child components directly because it won't get the path right;
-            // wrapping component in an array and skipping it's callback is a workaround to start with the correct path, but it is not ideal
+            // wrap component in an array to let eachComponentData handle introspection to child components (e.g. this will be different
+            // for data grids versus nested forms, etc.)
             eachComponentData([component], data, (thisComponent, data, row, path, components, index) => {
                 if (component.key === thisComponent.key) return;
                 if (!isComponentDataEmpty(thisComponent, data, path)) {

--- a/src/utils/unwind.ts
+++ b/src/utils/unwind.ts
@@ -141,7 +141,7 @@ export function unwind(form: any, submission: any) {
         var paths = filter(path.replace(new RegExp(".?" + component.key + "$"), '').split('.'));
         /* eslint-enable no-useless-escape */
         if (!hasDataPath && paths.length && !component.isInsideNestedForm) {
-            key = paths.map(function (subpath: any) { return subpath + "[0]"; }).join('.') + "." + component.key;
+            key = paths.join('.') + "." + component.key;
         }
         if (component.multiple) {
             paths.push(component.key);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8143

## Description

Updates `eachComponent` family of functions to return a `[0]` path when iterating over array data components

## Breaking Changes / Backwards Compatibility

Though this is a relatively small change, the impact of even small changes to `eachComponent` and `eachComponentData` can be enormous, because so much depends on them. I've written tests and existing tests pass, but special care should be taken whenever we change these particular functions.

## Dependencies

n/a

## How has this PR been tested?

Automated tests etc.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
