### PR TITLE
Fio 8177 fix unsetting empty array values

### DIFF
--- a/src/process/filter/__tests__/filter.test.ts
+++ b/src/process/filter/__tests__/filter.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+
+import { filterProcessSync } from '../';
+import { generateProcessorContext } from '../../__tests__/fixtures/util';
+
+it('Should not filter empty array value for dataGrid component', async () => {
+    const dataGridComp = {
+        type: 'datagrid',
+        key: 'dataGrid',
+        input: true,
+        path: 'dataGrid',
+        components: [
+            {
+                type: 'textfield',
+                key: 'textField',
+                input: true,
+                label: 'Text Field'
+            }
+        ]
+    };
+    const data = {
+        dataGrid: []
+    };
+    const context: any = generateProcessorContext(dataGridComp, data);
+    filterProcessSync(context);
+    expect(context.scope.filter).to.deep.equal({'dataGrid': true});
+});
+
+it('Should not filter empty array value for editGrid component', async () => {
+    const editGridComp = {
+        type: 'editgrid',
+        key: 'editGrid',
+        input: true,
+        path: 'editGrid',
+        components: [
+            {
+                type: 'textfield',
+                key: 'textField',
+                input: true,
+                label: 'Text Field'
+            }
+        ]
+    };
+    const data = {
+        editGrid: []
+    };
+    const context: any = generateProcessorContext(editGridComp, data);
+    filterProcessSync(context);
+    expect(context.scope.filter).to.deep.equal({'editGrid': true});
+});
+
+it('Should not filter empty array value for datTable component', async () => {
+    const dataTableComp = {
+        type: 'datatable',
+        key: 'dataTable',
+        input: true,
+        path: 'dataTable',
+        components: [
+            {
+                type: 'textfield',
+                key: 'textField',
+                input: true,
+                label: 'Text Field'
+            }
+        ]
+    };
+    const data = {
+        dataTable: []
+    };
+    const context: any = generateProcessorContext(dataTableComp, data);
+    filterProcessSync(context);
+    expect(context.scope.filter).to.deep.equal({'dataTable': true});
+});

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -15,6 +15,7 @@ export const filterProcessSync: ProcessorFnSync<FilterScope> = (context: FilterC
                 scope.filter[absolutePath] = {data: {}};
                 break;
             case 'array':
+                scope.filter[absolutePath] = true;
                 break;
             case 'object':
                 if (component.type !== 'container') {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8177

## Description

Filter processor was unsetting empty array values for dataGrid, editGrid, dataTable components. Now it preserves the values.

## Breaking Changes / Backwards Compatibility

Backwards compatible with 8.5

## Dependencies

no

## How has this PR been tested?

unit tests added

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
