### PR TITLE
FIO-8128: adds includeAll flag to eachComponentData and eachComponentDataAsync

### DIFF
--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -80,7 +80,6 @@ export function processSync<ProcessScope>(context: ProcessContext<ProcessScope>)
     return scope;
 }
 
-// Export a record of all the supported processors.
 export const ProcessorMap: Record<string, ProcessorInfo<any, any>> = {
     filter: filterProcessInfo,
     defaultValue: defaultValueProcessInfo,

--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -242,6 +242,292 @@ describe('getContextualRowData', () => {
 });
 
 describe('eachComponentDataAsync', () => {
+    it('Should iterate over each component and data given a flat components array', async () => {
+        const components = [
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            {
+                type: 'textarea',
+                key: 'textArea',
+                label: 'Text Area',
+                input: true,
+            }
+        ];
+        const data = {
+            textField: 'hello',
+            textArea: 'world',
+        };
+        const rowResults: Map<string, any> = new Map();
+        await eachComponentDataAsync(components, data, async (component, data, row, path) => {
+            const value = get(data, path);
+            rowResults.set(path, [component, value]);
+        });
+        expect(rowResults.size).to.equal(2);
+        expect(rowResults.get('textField')).to.deep.equal([
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            'hello'
+        ]);
+        expect(rowResults.get('textArea')).to.deep.equal([
+            {
+                type: 'textarea',
+                key: 'textArea',
+                label: 'Text Area',
+                input: true,
+            },
+            'world'
+        ]);
+    });
+
+    it('Should iterate over each component and data given a container component and a nested components array', async () => {
+        const components = [
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            {
+                type: 'container',
+                key: 'container',
+                label: 'Container',
+                input: true,
+                components: [
+                    {
+                        type: 'textfield',
+                        key: 'nestedTextField',
+                        label: 'Nested Text Field',
+                        input: true,
+                    },
+                    {
+                        type: 'textarea',
+                        key: 'nestedTextArea',
+                        label: 'Nested Text Area',
+                        input: true,
+                    }
+                ]
+            }
+        ];
+        const data = {
+            textField: 'hello',
+            container: {
+                nestedTextField: 'world',
+                nestedTextArea: 'foo',
+            },
+        };
+        const rowResults: Map<string, any> = new Map();
+        await eachComponentDataAsync(components, data, async (component, data, row, path) => {
+            const value = get(data, path);
+            rowResults.set(path, [component, value]);
+        });
+        expect(rowResults.size).to.equal(4);
+        expect(rowResults.get('textField')).to.deep.equal([
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            'hello'
+        ]);
+        expect(rowResults.get('container')).to.deep.equal([
+            {
+                type: 'container',
+                key: 'container',
+                label: 'Container',
+                input: true,
+                components: [
+                    {
+                        type: 'textfield',
+                        key: 'nestedTextField',
+                        label: 'Nested Text Field',
+                        input: true,
+                    },
+                    {
+                        type: 'textarea',
+                        key: 'nestedTextArea',
+                        label: 'Nested Text Area',
+                        input: true,
+                    }
+                ]
+            },
+            {
+                nestedTextField: 'world',
+                nestedTextArea: 'foo',
+            }
+        ]);
+        expect(rowResults.get('container.nestedTextField')).to.deep.equal([
+            {
+                type: 'textfield',
+                key: 'nestedTextField',
+                label: 'Nested Text Field',
+                input: true,
+            },
+            'world'
+        ]);
+        expect(rowResults.get('container.nestedTextArea')).to.deep.equal([
+            {
+                type: 'textarea',
+                key: 'nestedTextArea',
+                label: 'Nested Text Area',
+                input: true,
+            },
+            'foo'
+        ]);
+    });
+
+    it('Should iterate over each component and data given a datagrid component and a nested components array', async () => {
+        const components = [
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            {
+                type: 'datagrid',
+                key: 'dataGrid',
+                label: 'Data Grid',
+                input: true,
+                components: [
+                    {
+                        type: 'textfield',
+                        key: 'nestedTextField',
+                        label: 'Nested Text Field',
+                        input: true,
+                    },
+                    {
+                        type: 'textarea',
+                        key: 'nestedTextArea',
+                        label: 'Nested Text Area',
+                        input: true,
+                    }
+                ]
+            }
+        ];
+        const data = {
+            textField: 'hello',
+            dataGrid: [
+                {
+                    nestedTextField: 'world',
+                    nestedTextArea: 'foo',
+                },
+                {
+                    nestedTextField: 'bar',
+                    nestedTextArea: 'baz',
+                }
+            ],
+        };
+        const rowResults: Map<string, any> = new Map();
+        await eachComponentDataAsync(components, data, async (component, data, row, path) => {
+            const value = get(data, path);
+            rowResults.set(path, [component, value]);
+        });
+        expect(rowResults.size).to.equal(6);
+        expect(rowResults.get('textField')).to.deep.equal([
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            'hello'
+        ]);
+        expect(rowResults.get('dataGrid')).to.deep.equal([
+            {
+                type: 'datagrid',
+                key: 'dataGrid',
+                label: 'Data Grid',
+                input: true,
+                components: [
+                    {
+                        type: 'textfield',
+                        key: 'nestedTextField',
+                        label: 'Nested Text Field',
+                        input: true,
+                    },
+                    {
+                        type: 'textarea',
+                        key: 'nestedTextArea',
+                        label: 'Nested Text Area',
+                        input: true,
+                    }
+                ]
+            },
+            [
+                {
+                    nestedTextField: 'world',
+                    nestedTextArea: 'foo',
+                },
+                {
+                    nestedTextField: 'bar',
+                    nestedTextArea: 'baz',
+                }
+            ]
+        ]);
+        expect(rowResults.get('dataGrid[0].nestedTextField')).to.deep.equal([
+            {
+                type: 'textfield',
+                key: 'nestedTextField',
+                label: 'Nested Text Field',
+                input: true,
+            },
+            'world'
+        ]);
+    });
+
+    it('Should iterate over a components array and include components that are not in the data object if the includeAll flag is set to true', async () => {
+        const components = [
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            {
+                type: 'textarea',
+                key: 'textArea',
+                label: 'Text Area',
+                input: true,
+            }
+        ];
+        const data = {
+            textField: 'hello',
+        };
+        const rowResults: Map<string, [Component, unknown]> = new Map();
+        await eachComponentDataAsync(components, data, async (component, data, row, path) => {
+            const value = get(data, path);
+            rowResults.set(path, [component, value]);
+        }, undefined, undefined, undefined, true);
+        expect(rowResults.size).to.equal(2);
+        expect(rowResults.get('textField')).to.deep.equal([
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            'hello'
+        ]);
+        expect(rowResults.get('textArea')).to.deep.equal([
+            {
+                type: 'textarea',
+                key: 'textArea',
+                label: 'Text Area',
+                input: true,
+            },
+            undefined
+        ]);
+    });
+
     describe('Flattened form components (for evaluation)', () => {
         it('Should return the correct contextual row data for each component', async () => {
             const components = [

--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -1153,4 +1153,48 @@ describe('eachComponentData', () => {
             'world'
         ]);
     });
+
+    it('Should iterate over a components array and include components that are not in the data object if the includeAll flag is set to true', () => {
+        const components = [
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            {
+                type: 'textarea',
+                key: 'textArea',
+                label: 'Text Area',
+                input: true,
+            }
+        ];
+        const data = {
+            textField: 'hello',
+        };
+        const rowResults: Map<string, [Component, unknown]> = new Map();
+        eachComponentData(components, data, (component, data, row, path) => {
+            const value = get(data, path);
+            rowResults.set(path, [component, value]);
+        }, undefined, undefined, undefined, true);
+        expect(rowResults.size).to.equal(2);
+        expect(rowResults.get('textField')).to.deep.equal([
+            {
+                type: 'textfield',
+                key: 'textField',
+                label: 'Text Field',
+                input: true,
+            },
+            'hello'
+        ]);
+        expect(rowResults.get('textArea')).to.deep.equal([
+            {
+                type: 'textarea',
+                key: 'textArea',
+                label: 'Text Area',
+                input: true,
+            },
+            undefined
+        ]);
+    });
 });

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -284,7 +284,6 @@ export const eachComponentData = (
   index?: number,
   parent?: Component,
   includeAll: boolean = false
-  // pass flag to include components that do not have associated data
 ) => {
   if (!components || !data) {
     return;

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -220,7 +220,8 @@ export const eachComponentDataAsync = async (
   fn: AsyncComponentDataCallback,
   path = "",
   index?: number,
-  parent?: Component
+  parent?: Component,
+  includeAll: boolean = false
 ) => {
   if (!components || !data) {
     return;
@@ -242,11 +243,12 @@ export const eachComponentDataAsync = async (
               fn,
               `${compPath}[${i}]`,
               i,
-              component
+              component,
+              includeAll
             );
           }
           return true;
-        } else if (isEmpty(row)) {
+        } else if (isEmpty(row) && !includeAll) {
           // Tree components may submit empty objects; since we've already evaluated the parent tree/layout component, we won't worry about constituent elements
           return true;
         }
@@ -256,12 +258,12 @@ export const eachComponentDataAsync = async (
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
             const childPath: string = componentChildPath(component, path, compPath);
             const childData: any = get(data, childPath, null);
-            await eachComponentDataAsync(component.components, childData, fn, '', index, component);
+            await eachComponentDataAsync(component.components, childData, fn, '', index, component, includeAll);
             set(data, childPath, childData);
           }
         }
         else {
-          await eachComponentDataAsync(component.components, data, fn, componentChildPath(component, path, compPath), index, component);
+          await eachComponentDataAsync(component.components, data, fn, componentChildPath(component, path, compPath), index, component, includeAll);
         }
         return true;
       } else {
@@ -280,7 +282,9 @@ export const eachComponentData = (
   fn: ComponentDataCallback,
   path = "",
   index?: number,
-  parent?: Component
+  parent?: Component,
+  includeAll: boolean = false
+  // pass flag to include components that do not have associated data
 ) => {
   if (!components || !data) {
     return;
@@ -296,10 +300,10 @@ export const eachComponentData = (
         const value = get(data, compPath, data) as DataObject;
         if (Array.isArray(value)) {
           for (let i = 0; i < value.length; i++) {
-            eachComponentData(component.components, data, fn, `${compPath}[${i}]`, i, component);
+            eachComponentData(component.components, data, fn, `${compPath}[${i}]`, i, component, includeAll);
           }
           return true;
-        } else if (isEmpty(row)) {
+        } else if (isEmpty(row) && !includeAll) {
           // Tree components may submit empty objects; since we've already evaluated the parent tree/layout component, we won't worry about constituent elements
           return true;
         }
@@ -309,12 +313,12 @@ export const eachComponentData = (
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
             const childPath: string = componentChildPath(component, path, compPath);
             const childData: any = get(data, childPath, {});
-            eachComponentData(component.components, childData, fn, '', index, component);
+            eachComponentData(component.components, childData, fn, '', index, component, includeAll);
             set(data, childPath, childData);
           }
         }
         else {
-          eachComponentData(component.components, data, fn, componentChildPath(component, path, compPath), index, component);
+          eachComponentData(component.components, data, fn, componentChildPath(component, path, compPath), index, component, includeAll);
         }
         return true;
       } else {
@@ -559,11 +563,11 @@ export function getComponentData(components: Component[], data: DataObject, path
 }
 
 export function getComponentActualValue(component: Component, compPath: string, data: any, row: any) {
-  // The compPath here will NOT contain the indexes for DataGrids and EditGrids. 
+  // The compPath here will NOT contain the indexes for DataGrids and EditGrids.
   //
   //   a[0].b[2].c[3].d
   //
-  // Because of this, we will need to determine our parent component path (not data path), 
+  // Because of this, we will need to determine our parent component path (not data path),
   // and find the "row" based comp path.
   //
   //   a[0].b[2].c[3].d => a.b.c.d


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8128

## Description

Adds an optional `includeAll` flag to `eachComponentData` and `eachComponentDataAsync` that will (on an opt-in basis) allow those two functions to iterate over components even when those components do not have an associated data object.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I wrote automated tests, and existing tests pass. Upstream, I tested versus tests in @formio/vm and formio-server@9.0.0 and everything is passing.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
