### PR TITLE
FIO-8264: update validate required

### DIFF
--- a/src/process/validation/rules/__tests__/fixtures/components.ts
+++ b/src/process/validation/rules/__tests__/fixtures/components.ts
@@ -204,6 +204,14 @@ export const simpleRadioField: RadioComponent = {
     input: true,
 };
 
+export const simpleCheckBoxField = {
+    label: 'Checkbox',
+    tableView: true,
+    key: 'component',
+    type: 'checkbox',
+    input: true,
+};
+
 export const hiddenRequiredField: HiddenComponent = {
     type: 'hidden',
     key: 'someData',

--- a/src/process/validation/rules/__tests__/validateRequired.test.ts
+++ b/src/process/validation/rules/__tests__/validateRequired.test.ts
@@ -2,10 +2,18 @@ import { expect } from 'chai';
 
 import { FieldError } from 'error';
 import { validateRequired } from '../validateRequired';
-import { conditionallyHiddenRequiredHiddenField, hiddenRequiredField, requiredNonInputField, simpleTextField } from './fixtures/components';
+import {
+    conditionallyHiddenRequiredHiddenField,
+    hiddenRequiredField,
+    requiredNonInputField,
+    simpleTextField,
+    simpleSelectBoxes,
+    simpleRadioField,
+    simpleCheckBoxField,
+} from './fixtures/components';
 import { processOne } from 'processes/processOne';
 import { generateProcessorContext } from './fixtures/util';
-import { ProcessorsContext, ValidationScope } from 'types';
+import { ProcessorsContext, SelectBoxesComponent, ValidationScope } from 'types';
 import { validateAllProcess, validateProcessInfo } from 'processes/validation';
 
 it('Validating a simple component that is required and not present in the data will return a field error', async () => {
@@ -116,7 +124,7 @@ it('Should not validate a non input comonent', async () => {
     expect(context.scope.errors.length).to.equal(0);
 });
 
-it('Should validate a conditionally hidden compoentn with validateWhenHidden flag set to true', async () => {
+it('Should validate a conditionally hidden component with validateWhenHidden flag set to true', async () => {
     const component = {...simpleTextField};
     component.validate = { required: true };
     component.validateWhenHidden = true;
@@ -131,4 +139,67 @@ it('Should validate a conditionally hidden compoentn with validateWhenHidden fla
     await processOne(context);
     expect(context.scope.errors.length).to.equal(1);
     expect(context.scope.errors[0] && context.scope.errors[0].errorKeyOrMessage).to.equal('required');
+});
+
+it('Validating a simple radio component that is required and present in the data with value set to false will return null', async () => {
+    const component = { ...simpleRadioField, validate: { required: true }, values: [
+        {
+            label: 'Yes',
+            value: 'true',
+        },
+        {
+            label: 'No',
+            value: 'false',
+        }] };
+    const data = { component: false };
+    const context = generateProcessorContext(component, data);
+    const result = await validateRequired(context);
+    expect(result).to.equal(null);
+});
+
+
+it('Validating a simple selectbox that is required and present in the data with value set to 0 will return null', async () => {
+    const component = { ...simpleSelectBoxes, validate: { required: true }, values: [
+        {
+            label: 'true',
+            value: 'true',
+        },
+        {
+            label: 'Null',
+            value: '0',
+        }] };
+    const data = { component: 0 };
+    const context = generateProcessorContext(component, data);
+    const result = await validateRequired(context);
+    expect(result).to.equal(null);
+});
+
+it('Validating a simple selectbox that is required and present in the data with value set to false will return a FieldError', async () => {
+    const component: SelectBoxesComponent = { ...simpleSelectBoxes, validate: { required: true }, values: [
+        {
+            label: 'true',
+            value: 'true',
+        },
+        {
+            label: 'false',
+            value: 'false',
+        }]
+    };
+    const data = {
+        component: {
+            true: false,
+            false: false
+        }
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateRequired(context);
+    expect(result).to.be.instanceOf(FieldError);
+});
+
+it('Validating a simple checkbox that is required and present in the data with value set to false will return a FieldError', async () => {
+    const component = { ...simpleCheckBoxField, validate: { required: true } };
+    const data = { component: false };
+    const context = generateProcessorContext(component, data);
+    const result = await validateRequired(context);
+    expect(result).to.be.instanceOf(FieldError);
 });

--- a/src/process/validation/rules/validateRequired.ts
+++ b/src/process/validation/rules/validateRequired.ts
@@ -76,10 +76,7 @@ export const validateRequiredSync: RuleFnSync = (context: ValidationContext) => 
     else if (isComponentThatCannotHaveFalseValue(component)) {
         return !valueIsPresent(value, false) ? error : null;
     }
-    else if (!valueIsPresent(value, true)) {
-        return error;
-    }
-    return null;
+    return !valueIsPresent(value, true) ? error : null;
 };
 
 export const validateRequiredInfo: ProcessorInfo<ValidationContext, FieldError | null>  = {

--- a/src/types/Component.ts
+++ b/src/types/Component.ts
@@ -328,15 +328,29 @@ export type ListComponent = BaseComponent & {
     valueProperty?: string;
 };
 
-export type RadioComponent = ListComponent & {
+type StaticValuesRadioComponent = ListComponent & {
     values: { label: string; value: string; shortcut?: string }[];
-    data?: {
-        url?: string;
-    };
+    dataSrc?: "values";
     fieldSet?: boolean;
     optionsLabelPosition?: string;
     inline?: boolean;
 };
+
+type UrlValuesRadioComponent = ListComponent & {
+    data: {
+        url: string;
+        headers: {
+            key: string;
+            value: string;
+        }[];
+    };
+    dataSrc: 'url';
+    fieldSet?: boolean;
+    optionsLabelPosition?: string;
+    inline?: boolean;
+};
+
+export type RadioComponent = StaticValuesRadioComponent | UrlValuesRadioComponent;
 
 export type RecaptchaComponent = BaseComponent;
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8264

## Description

Checkbox and selectboxes components that are required will treat `false` as a falsy value. In other words, if the component (or one of its constituents) is not checked and that component is required, it is not a valid submission. Other components (e.g. container, data map, select, radio buttons) can have `false` as a value and not be treated as invalid, which was not accounted for in the required validation rule. This PR tightens required validation by:

* not evaluating at all if the component's `hidden` property is true;
* not considering `false` a falsy value unless the component is a checkbox or a selectboxes component; 
* recursively iterating over object values to ensure nested components don't suffer from the same problem; and
* adding minor updates to the Radio component type.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

added tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
