### PR TITLE
FIO-8288: do not validate dates in textfield components with calendar widgets

### DIFF
--- a/src/process/validation/rules/__tests__/validateDate.test.ts
+++ b/src/process/validation/rules/__tests__/validateDate.test.ts
@@ -73,44 +73,12 @@ it('Validating a textField calendar picker component with no data will return nu
     expect(result).to.equal(null);
 });
 
-it('Validating a textField calendar picker component with an invalid date string value will return a FieldError', async () => {
+it('Textfield calendar picker component date values should not be validated and return null', async () => {
     const component = calendarTextField;
     const data = {
         component: 'hello, world!',
     };
     const context = generateProcessorContext(component, data);
     const result = await validateDate(context);
-    expect(result).to.be.instanceOf(FieldError);
-    expect(result?.errorKeyOrMessage).to.equal('invalidDate');
-});
-
-it('Validating a textField calendar picker component with an valid date string value will return null', async () => {
-    const component = calendarTextField;
-    const data = {
-        component: '2023-03-09T12:00:00-06:00',
-    };
-    const context = generateProcessorContext(component, data);
-    const result = await validateDate(context);
-    expect(result).to.equal(null);
-});
-
-it('Validating a textField calendar picker component with an invalid Date object will return a FieldError', async () => {
-    const component = calendarTextField;
-    const data = {
-        component: new Date('Hello, world!'),
-    };
-    const context = generateProcessorContext(component, data);
-    const result = await validateDate(context);
-    expect(result).to.be.instanceOf(FieldError);
-    expect(result?.errorKeyOrMessage).to.equal('invalidDate');
-});
-
-it('Validating a textField calendar picker component with a valid Date object will return null', async () => {
-    const component = calendarTextField;
-    const data = {
-        component: new Date(),
-    };
-    const context = generateProcessorContext(component, data);
-    const result = await validateDate(context);
-    expect(result).to.equal(null);
+    expect(result).to.be.equal(null);
 });

--- a/src/process/validation/rules/validateDate.ts
+++ b/src/process/validation/rules/validateDate.ts
@@ -6,12 +6,8 @@ const isValidatableDateTimeComponent = (obj: any): obj is DateTimeComponent => {
     return !!obj && !!obj.type && obj.type === 'datetime';
 };
 
-const isValidatableTextFieldComponent = (obj: any): obj is TextFieldComponent => {
-    return !!obj && !!obj.type && obj.widget && obj.widget.type === 'calendar';
-};
-
 const isValidatable = (component: any) => {
-    return isValidatableDateTimeComponent(component) || isValidatableTextFieldComponent(component);
+    return isValidatableDateTimeComponent(component);
 };
 
 export const shouldValidate = (context: ValidationContext) => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8288

## Description

Previous versions of the Enterprise Server didn't validate textfield component (with calendar widget) date values. This PR updates the date validation rule to ignore textfield components with the calendar widget.

This kind of makes sense - it's almost as if by selecting the calendar widget on a textfield rather than a date/time component, you're opting into client-side manipulation only and the end result will be merely a string in the database (rather than, say, an ISO string that can easily be converted, parsed, etc.).

## Breaking Changes / Backwards Compatibility

This unifies 9.x behavior with 8.x behavior. 

## Dependencies

n/a

## How has this PR been tested?

I've updated the automated tests to reflect the new (old?) expected behavior, and existing formio and formio-server tests pass.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
