### PR TITLE
FIO-8281: fixed sync validation error for select component with url d…

### DIFF
--- a/src/process/validation/rules/__tests__/validateAvailableItems.test.ts
+++ b/src/process/validation/rules/__tests__/validateAvailableItems.test.ts
@@ -9,7 +9,7 @@ import {
     simpleSelectOptions,
 } from './fixtures/components';
 import { generateProcessorContext } from './fixtures/util';
-import { validateAvailableItems } from '../validateAvailableItems';
+import { validateAvailableItems, validateAvailableItemsSync } from '../validateAvailableItems';
 
 it('Validating a component without the available items validation parameter will return null', async () => {
     const component = simpleTextField;
@@ -117,6 +117,43 @@ it('Validating a simple URL select component without the available items validat
     };
     const context = generateProcessorContext(component, data);
     const result = await validateAvailableItems(context);
+    expect(result).to.equal(null);
+});
+
+it('Validating a simple URL select component synchronously will return null', async () => {
+    const component: SelectComponent = {
+        ...simpleSelectOptions,
+        dataSrc: 'url',
+        data: {
+            url: 'http://localhost:8080/numbers',
+            headers: [],
+        },
+        validate: { onlyAvailableItems: true },
+    };
+    const data = {
+        component: 'foo',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = validateAvailableItemsSync(context);
+    expect(result).to.equal(null);
+});
+
+it('Validating a multiple URL select component synchronously will return null', async () => {
+    const component: SelectComponent = {
+        ...simpleSelectOptions,
+        dataSrc: 'url',
+        data: {
+            url: 'http://localhost:8080/numbers',
+            headers: [],
+        },
+        multiple: true,
+        validate: { onlyAvailableItems: true },
+    };
+    const data = {
+        component: ['foo'],
+    };
+    const context = generateProcessorContext(component, data);
+    const result = validateAvailableItemsSync(context);
     expect(result).to.equal(null);
 });
 

--- a/src/process/validation/rules/validateAvailableItems.ts
+++ b/src/process/validation/rules/validateAvailableItems.ts
@@ -156,6 +156,8 @@ function getAvailableSelectValuesSync(component: SelectComponent, context: Valid
                     'validate:validateAvailableItems'
                 );
             }
+        case 'url':
+            return null;
         default:
             throw new ProcessorError(
                 `Failed to validate available values in select component '${component.key}': data source ${component.dataSrc} is not valid}`,


### PR DESCRIPTION
…ata src

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8281

## Description

Added 'url' data src case for sync available items check. As it's impossible to check values from 'url' data src in the sync version, just return null. I did this change because in the builder mode any url select component with default value throws validation error. It doesn't allow to save configuration for the multiple select component.
![image](https://github.com/formio/core/assets/24360267/341c2deb-cbb8-4dbb-ac98-30719c9b9183)
![image](https://github.com/formio/core/assets/24360267/9f562f7d-5dd7-4dfa-b816-e0f5f93f9962)

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
