### PR TITLE
FIO-8254 fixed available values validation error for Select component

### DIFF
--- a/src/process/validation/rules/__tests__/validateAvailableItems.test.ts
+++ b/src/process/validation/rules/__tests__/validateAvailableItems.test.ts
@@ -103,6 +103,28 @@ it('Validating a simple static values select component with the available items 
     expect(result).to.equal(null);
 });
 
+it('Validating a simple static values select component with the available items validation parameter will return null if the selected item is valid and dataSrc is not specified', async () => {
+    const component: SelectComponent = {
+        ...simpleSelectOptions,
+        dataSrc: undefined,
+        data: {
+            values: [
+                { label: 'foo', value: 'foo' },
+                { label: 'bar', value: 'bar' },
+                { label: 'baz', value: 'baz' },
+                { label: 'baz', value: 'baz' },
+            ],
+        },
+        validate: { onlyAvailableItems: true },
+    };
+    const data = {
+        component: 'foo',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateAvailableItems(context);
+    expect(result).to.equal(null);
+});
+
 it('Validating a simple URL select component without the available items validation parameter will return null', async () => {
     const component: SelectComponent = {
         ...simpleSelectOptions,

--- a/src/process/validation/rules/validateAvailableItems.ts
+++ b/src/process/validation/rules/validateAvailableItems.ts
@@ -1,4 +1,4 @@
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty, isUndefined} from 'lodash';
 import { FieldError, ProcessorError } from 'error';
 import { Evaluator } from 'utils';
 import { RadioComponent, SelectComponent, RuleFn, RuleFnSync, ValidationContext } from 'types';
@@ -37,6 +37,9 @@ function mapStaticValues(values: { label: string; value: string }[]) {
 }
 
 async function getAvailableSelectValues(component: SelectComponent, context: ValidationContext) {
+    if (isUndefined(component.dataSrc) && component.data.hasOwnProperty('values')) {
+        component.dataSrc = 'values';
+    };
     switch (component.dataSrc) {
         case 'values':
             if (Array.isArray(component.data.values)) {
@@ -107,6 +110,9 @@ async function getAvailableSelectValues(component: SelectComponent, context: Val
 }
 
 function getAvailableSelectValuesSync(component: SelectComponent, context: ValidationContext) {
+    if (isUndefined(component.dataSrc) && component.data.hasOwnProperty('values')) {
+        component.dataSrc = 'values';
+    };
     switch (component.dataSrc) {
         case 'values':
             if (Array.isArray(component.data?.values)) {

--- a/src/types/Component.ts
+++ b/src/types/Component.ts
@@ -344,7 +344,7 @@ type StaticValuesSelectData = {
     data: {
         values: { label: string; value: string }[];
     };
-    dataSrc: 'values';
+    dataSrc?: undefined | 'values';
 };
 
 type JsonValuesSelectData = {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8254

## Description

*The DataSrc property is an optional property and is set to values by default. Therefore, by default, the dataSrc property is not specified for Select components with Data Source Type as values. A check for the possible Data Source Type as values was added. Now the  Select components with validation of only available values work as expected, including forms of earlier versions*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated tests have been added. All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
