### PR TITLE
FIO-8354: fallback to passing response in argument if response.body is undefined

### DIFF
--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -1566,13 +1566,13 @@ export class Formio {
       if (!response.ok) {
         if (response.status === 440) {
           Formio.setToken(null, opts);
-          Formio.events.emit('formio.sessionExpired', response.body);
+          Formio.events.emit('formio.sessionExpired', response.body || response);
         }
         else if (response.status === 401) {
-          Formio.events.emit('formio.unauthorized', response.body);
+          Formio.events.emit('formio.unauthorized', response.body || response);
         }
         else if (response.status === 416) {
-          Formio.events.emit('formio.rangeIsNotSatisfiable', response.body);
+          Formio.events.emit('formio.rangeIsNotSatisfiable', response.body || response);
         }
         else if (response.status === 504) {
           return Promise.reject(new Error('Network request failed'));

--- a/src/sdk/__tests__/Formio.test.ts
+++ b/src/sdk/__tests__/Formio.test.ts
@@ -2173,4 +2173,60 @@ describe('Formio.js Tests', () => {
       assert.ok(plugin.wrapStaticRequestPromise.calledOnce, 'wrapStaticRequestPromise should be called once');
     });
   });
+  describe('Formio.request', () => {
+    it('should emit a formio.sessionExpired event when the response status is 440 and the response object should exist', (done) => {
+      let eventFired = false
+      let responseNotUndefined = false
+      setTimeout(()=>{
+        assert(eventFired, 'formio.sessionExpired event was not called');
+        assert(responseNotUndefined, 'a response was not passed into the event');
+        fetchMock.restore()
+        done()
+      },200)
+      Formio.events.on('formio.sessionExpired', (response: any) => {
+        eventFired = true
+        if (response){
+          responseNotUndefined = true
+        }
+      })
+      fetchMock.mock('http://localhost:8080/test', 440);
+      Formio.request('http://localhost:8080/test');
+    });
+    it('should emit a formio.unauthorized event when the response status is 401', (done) => {
+      let eventFired = false
+      let responseNotUndefined = false
+      setTimeout(()=>{
+        assert(eventFired, 'formio.unauthorized event was not called');
+        assert(responseNotUndefined, 'a response was not passed into the event');
+        fetchMock.restore()
+        done()
+      },200);
+      Formio.events.on('formio.unauthorized', (response: any) => {
+        eventFired = true;
+        if (response){
+          responseNotUndefined = true;
+        }
+      })
+      fetchMock.mock('http://localhost:8080/test', 401);
+      Formio.request('http://localhost:8080/test');
+    });
+    it('should emit a formio.rangeIsNotSatisfiable event when the response status is 416', (done) => {
+      let eventFired = false;
+      let responseNotUndefined = false;
+      setTimeout(()=>{
+        assert(eventFired, 'formio.rangeIsNotSatisfiable event was not called');
+        assert(responseNotUndefined, 'a response was not passed into the event');
+        fetchMock.restore()
+        done()
+      },200);
+      Formio.events.on('formio.rangeIsNotSatisfiable', (response) => {
+        eventFired = true;
+        if (response) {
+          responseNotUndefined = true;
+        }
+      })
+      fetchMock.mock('http://localhost:8080/test', 416);
+      Formio.request('http://localhost:8080/test');
+    });
+  });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8354

## Description

**What changed?**

Changed the events emitted by Formio to fallback to passing the response object to emit argument if response.body is undefined. This allows for clients using this api to handle these events based on the data in the response object.

I chose this solution because it allows for backwards compatibility by keeping response.body as a possible argument in the emit function

## Breaking Changes / Backwards Compatibility

None

## Dependencies

N/A

## How has this PR been tested?

manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
