### PR TITLE
update validate required recursion to not recurse when nested data type

### DIFF
--- a/src/process/normalize/index.ts
+++ b/src/process/normalize/index.ts
@@ -254,6 +254,10 @@ const normalizeTextFieldComponentValue = (
     value: any,
     path: string
 ) => {
+    // If the component has truncate multiple spaces enabled, then normalize the value to remove extra spaces.
+    if (component.truncateMultipleSpaces && typeof value === 'string') {
+        value = value.trim().replace(/\s{2,}/g, ' ');
+    }
     if (component.allowMultipleMasks && component.inputMasks && component.inputMasks.length > 0) {
         if (Array.isArray(value)) {
             return value.map((val) => normalizeMaskValue(component, defaultValues, val, path));

--- a/src/process/validation/rules/validateRequired.ts
+++ b/src/process/validation/rules/validateRequired.ts
@@ -8,7 +8,7 @@ import {
     DayComponent
 } from 'types';
 import { isEmptyObject } from '../util';
-import { isComponentNestedDataType } from 'utils/formUtil.js';
+import { isComponentNestedDataType } from 'utils/formUtil';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 
 const isAddressComponent = (component: any): component is AddressComponent => {

--- a/src/process/validation/rules/validateRequired.ts
+++ b/src/process/validation/rules/validateRequired.ts
@@ -8,6 +8,7 @@ import {
     DayComponent
 } from 'types';
 import { isEmptyObject } from '../util';
+import { isComponentNestedDataType } from 'utils/formUtil.js';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 
 const isAddressComponent = (component: any): component is AddressComponent => {
@@ -28,7 +29,7 @@ const isComponentThatCannotHaveFalseValue = (component: any): boolean => {
     return component.type === 'checkbox' || component.type === 'selectboxes'
 }
 
-const valueIsPresent = (value: any, considerFalseTruthy: boolean): boolean => {
+const valueIsPresent = (value: any, considerFalseTruthy: boolean, isNestedDatatype?: boolean): boolean => {
     // Evaluate for 3 out of 6 falsy values ("", null, undefined), don't check for 0
     // and only check for false under certain conditions
     if (value === null || value === undefined || value === "" || (!considerFalseTruthy && value === false)) {
@@ -43,7 +44,7 @@ const valueIsPresent = (value: any, considerFalseTruthy: boolean): boolean => {
         return false;
     }
     // Recursively evaluate
-    else if (typeof value === 'object') {
+    else if (typeof value === 'object' && !isNestedDatatype) {
         return Object.values(value).some((val) => valueIsPresent(val, considerFalseTruthy));
     }
     return true;
@@ -74,9 +75,9 @@ export const validateRequiredSync: RuleFnSync = (context: ValidationContext) => 
         return error;
     }
     else if (isComponentThatCannotHaveFalseValue(component)) {
-        return !valueIsPresent(value, false) ? error : null;
+        return !valueIsPresent(value, false, isComponentNestedDataType(component)) ? error : null;
     }
-    return !valueIsPresent(value, true) ? error : null;
+    return !valueIsPresent(value, true, isComponentNestedDataType(component)) ? error : null;
 };
 
 export const validateRequiredInfo: ProcessorInfo<ValidationContext, FieldError | null>  = {


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

The `validateRequired` rule needs to recursively evaluate objects (like select boxes), but it should not recursively evaluate nested data types (such as data grids, edit grids, etc.).

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I've added automated tests. (coming soon...)

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
