### PR TITLE
FIO-7675: Map Key From Core

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -421,7 +421,7 @@ describe('Process Tests', () => {
                                             type: "address",
                                             providerOptions: {
                                                 params: {
-                                                    key: "AIzaSyBNL2e4MnmyPj9zN7SVAe428nCSLP1X144",
+                                                    key: "",
                                                     region: "",
                                                     autocompleteOptions: {
                                                     },
@@ -721,7 +721,7 @@ describe('Process Tests', () => {
                                                     type: "address",
                                                     providerOptions: {
                                                         params: {
-                                                            key: "AIzaSyBNL2e4MnmyPj9zN7SVAe428nCSLP1X144",
+                                                            key: "",
                                                             region: "",
                                                             autocompleteOptions: {
                                                             },


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7675

## Description

**What changed?**

Remove key from core. Believe @formio/core and @formio/js were running in parallel when the change to formio.js was made and Dane had pinged me so I double checked and notice key in the tests of core.

https://github.com/formio/formio.js/pull/5526

**Why have you chosen this solution?**

Key shouldn't be available in repo. 

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

n/a

## How has this PR been tested?

Not present in new dev tag from this PR

When using the dev tag `2.0.0-dev.103.ec176d1` no longer see the key appear in packages within formio-server
![image](https://github.com/formio/core/assets/112976114/922255cf-478c-401d-b98d-1357162964af)

When searching..
![image](https://github.com/formio/core/assets/112976114/bcc41ef9-1a06-415a-a25f-de9816619f15)

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
