### PR TITLE
FIO-8477: Fix the timezones issue in formatDate function

### DIFF
--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { formatDate } from '../date';
+
+describe('Test Date Utils', () => {
+  it('Should format date without timezone correctly', () => {
+    const value = '2023-04-01T12:00:00Z';
+    const format = 'YYYY-MM-DD';
+    const expected = '2023-04-01';
+    expect(formatDate(value, format)).to.equal(expected);
+  });
+
+  it('Should format date in UTC timezone correctly', () => {
+    const value = '2023-04-01T12:00:00Z';
+    const format = 'YYYY-MM-DD HH:mm:ss';
+    const timezone = 'UTC';
+    const expected = '2023-04-01 12:00:00 UTC';
+    expect(formatDate(value, format, timezone)).to.equal(expected);
+  });
+
+  it('Should format date in a specific timezone correctly', () => {
+    const value = '2023-04-01T12:00:00Z';
+    const format = 'YYYY-MM-DD HH:mm:ss';
+    expect(formatDate(value, format, 'America/New_York')).to.equal('2023-04-01 08:00:00 EDT');
+    // TODO: Fix expected value when dayjs issue is resolved
+    // https://github.com/iamkun/dayjs/issues/1154
+    // expect(formatDate(value, format, 'Europe/London')).to.equal('2023-04-01 13:00:00 BST');
+    expect(formatDate(value, format, 'Europe/London')).to.equal('2023-04-01 13:00:00 GMT+1');
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,12 +1,15 @@
-import dayjs from 'dayjs';
+import dayjs, { ConfigType } from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { isNaN, isNil } from 'lodash';
 import { Evaluator } from './Evaluator';
 import { DayComponent } from 'types';
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(advancedFormat);
 dayjs.extend(customParseFormat);
 
 /**
@@ -64,15 +67,17 @@ export function momentDate(value: any, format: any, timezone: any): any {
  * @param timezone
  * @return {string}
  */
-export function formatDate(value: any, format: any, timezone: any): string {
-    const momentDate = dayjs(value);
+export function formatDate(value: ConfigType, format: string, timezone?: string): string {
+    const date = dayjs(value);
+    const dayjsFormat = convertFormatToMoment(format);
+
     if (timezone === 'UTC') {
-        return `${dayjs.utc().format(convertFormatToMoment(format))} UTC`;
+        return `${date.utc().format(dayjsFormat)} UTC`;
     }
     if (timezone) {
-        return momentDate.tz(timezone).format(`${convertFormatToMoment(format)} z`);
+        return date.tz(timezone).format(`${dayjsFormat} z`);
     }
-    return momentDate.format(convertFormatToMoment(format));
+    return date.format(dayjsFormat);
 }
 
 /**


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8477

## Description

This PR addresses issues encountered with the `formatDate` function, originally implemented in the formio.js library, which utilizes the moment-timezone library for timezone formatting. Specifically, the `z` [format option](https://momentjs.com/timezone/docs/#/using-timezones/formatting/) in moment-timezone, used for abbreviated timezone names, does not directly translate to the dayjs library we currently employ. To bridge this functionality gap, the [advancedFormat](https://day.js.org/docs/en/plugin/advanced-format) plugin from dayjs is necessary. However, a known issue with dayjs ([#1154](https://github.com/iamkun/dayjs/issues/1154)) results in the generation of `GMT+..` formats instead of abbreviated timezone names. Notably, the `zzz` format option in dayjs correctly provides the full timezone name.
![image](https://github.com/formio/core/assets/24360267/57a83f4b-9564-4832-96d9-9b4dc8eb502b)


During the process of integrating the [advancedFormat](https://day.js.org/docs/en/plugin/advanced-format) plugin and updating the `formatDate` function, I also discovered and addressed a separate issue related to UTC formatting. Previously, the `formatDate` function incorrectly used the current date for UTC conversions instead of the provided date value.

## How has this PR been tested?

Unit testing

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
