### PR TITLE
FIO-8650 -- returning empty array for empty edit grids

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -2862,6 +2862,29 @@ describe('Process Tests', () => {
           components: [nestedForm],
         },
       ];
+      it('should return empty array when no data is provided', async () => {
+        const submission = {
+          data: {
+            editGrid: [],
+          },
+        };
+        const context = {
+          form: { components },
+          submission,
+          data: submission.data,
+          components,
+          processors: ProcessTargets.submission,
+          scope: {},
+          config: {
+            server: true,
+          },
+        };
+        processSync(context);
+        context.processors = ProcessTargets.evaluator;
+        processSync(context);
+        expect(context.data).to.deep.equal({ editGrid: [] });
+
+      })
       it('Should validate required component when it is filled out', async () => {
         const submission = {
           data: {
@@ -2924,6 +2947,7 @@ describe('Process Tests', () => {
         processSync(context);
         expect((context.scope as ValidationScope).errors).to.have.length(1);
       });
+      
     });
   });
   /*

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -61,15 +61,18 @@ export const filterPostProcess: ProcessorFnSync<FilterScope> = (
   context: FilterContext
 ) => {
   const { scope, component, submission } = context;
-  let filtered = {};
+  let filtered: Record<string, object> = {};
   for (const path in scope.filter) {
+    let value = get(submission?.data, path) as any;
     const pathFilter = scope.filter[path];
-    if (pathFilter.compModelType === 'array') {
-      continue;
-    }
-    if (pathFilter) {
-      let value = get(submission?.data, path) as any;
 
+    if (pathFilter.compModelType === 'array') {
+      // special case for array, if it's empty, set it to empty array
+      if(value.length === 0) {
+        filtered[path] = []
+      }
+      continue;
+    } else if (pathFilter) {
       // when it's a dataModel Object, don't set values directly on the data object, let child fields do that.
       // it can have extra data on updates, so pass all other values except data
       // standard lodash set function will mutate original value, using the functional version so it doesn't


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8650

## Description

**What changed?**
The filter logic was skipping array model types, letting the child fields populate the data object.  This wasn't working for empty grids. 

Added a special case for array model types when the data is empty.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
