### PR TITLE
fixing child components being displayed when they should be removed when clearOnHide is set

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -2938,7 +2938,7 @@ describe('Process Tests', () => {
         }
       ],
           
-        };
+    };
         const submission = {
           "data": {
               "candidates": [
@@ -2977,7 +2977,188 @@ describe('Process Tests', () => {
           submit: true
 
         });
+    
       })
+    it('Should not return fields from conditionally hidden containers, clearOnHide = false', async () => {
+        
+        const TestForm45588WithClearOnHideFalse = {
+          display: 'form',
+          "components": [
+        {
+          "title": "__information_on_the_appointee",
+          "theme": "primary",
+          "collapsible": false,
+          "key": "HeadingNestedFormCandidates",
+          "type": "panel",
+          "label": "Appointees",
+          "input": false,
+          "tableView": false,
+          "components": [
+            {
+              "label": "Appointees",
+              "hideLabel": true,
+              "tableView": false,
+              
+              "addAnother": "__add_appointee",
+              "modal": true,
+              "saveRow": "Close",
+              "rowDrafts": true,
+              "key": "candidates",
+              "type": "editgrid",
+              "displayAsTable": false,
+              "input": true,
+              "components": [
+                {
+                  "label": "Appointee",
+                  "tableView": false,
+                  "key": "candidate",
+                  "type": "container",
+                  "input": true,
+                  "components": [
+                    {
+                      "label": "Data",
+                      "tableView": false,
+                      "key": "data",
+                      "type": "container",
+                      "input": true,
+                      "components": [
+                        {
+                          "label": "Tabs",
+                          "components": [
+                            {
+                              "label": "__6_time_commitment",
+                              "key": "section6tab",
+                              "components": [
+                                {
+                                  "label": "Section 6",
+                                  "tableView": false,
+                                  "clearOnHide": false,
+                                  "validateWhenHidden": false,
+                                  "key": "section6",
+                                  "properties": {
+                                    "clearHiddenOnSave": "true"
+                                  },
+                                  "customConditional": "show = false;",
+                                  "type": "container",
+                                  "input": true,
+                                  "components": [
+                                    {
+                                      "title": "__6_dash_time_commitment",
+                                      "theme": "primary",
+                                      "collapsible": false,
+                                      "key": "heading6",
+                                      "type": "panel",
+                                      "label": "Time Commitment",
+                                      "input": false,
+                                      "tableView": false,
+                                      "components": [
+                                        {
+                                          "label": "__a_information_to_be_provided_by_the_supervised_entity_the",
+                                          "description": "__ul_li_see_the_report_on_declared_time_commitment_of",
+                                          "autoExpand": false,
+                                          "tableView": true,
+                                          "validate": {
+                                            "required": true
+                                          },
+                                          "key": "entityExpectedTimeCommit",
+                                          "type": "textarea",
+                                          "input": true
+                                        },
+                                        {
+                                          "label": "c",
+                                          "tableView": false,
+                                          "key": "c",
+                                          "type": "container",
+                                          "input": true,
+                                          "components": []
+                                        },
+                                        {
+                                          "label": "__d_list_of_executive_and_non_executive_directorships_and_other",
+                                          "description": "__for_each_directorship_or_other_activity_a_separate_row_needs",
+                                          "tableView": false,
+                                          "addAnother": "__add_another",
+                                          "validate": {
+                                            "required": true
+                                          },
+                                          "rowDrafts": false,
+                                          "key": "d",
+                                          "type": "editgrid",
+                                          "input": true,
+                                          "components": []
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "key": "tabs1",
+                          "type": "tabs",
+                          "input": false,
+                          "tableView": false
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Submit",
+          "action": "saveState",
+          "showValidations": false,
+          "tableView": false,
+          "key": "submit",
+          "type": "button",
+          "input": true,
+          "state": "draft"
+        }
+      ],
+          
+    };
+        
+        const submission = {
+          "data": {
+              "candidates": [
+                  {
+                      "candidate": {
+                          "data": {
+                              "section6": {
+                                  "c": {},
+                                  "d": []
+                              }
+                          }
+                      }
+                  }
+              ],
+              "submit": true
+          }
+        };
+
+        const context = {
+          form: TestForm45588WithClearOnHideFalse,
+          submission,
+          data: submission.data,
+          components: TestForm45588WithClearOnHideFalse.components,
+          processors: ProcessTargets.submission,
+          scope: {},
+          config: {
+            server: true,
+          },
+        };
+        processSync(context);
+        context.processors = ProcessTargets.evaluator;
+        processSync(context);
+        console.log(JSON.stringify(context.data, null, 2))
+        expect(context.data).to.deep.equal({
+          candidates:[{candidate:{data:{section6:{}}}}],
+          submit: true
+
+        });
+    })
 
     describe('For EditGrid:', () => {
       const components = [

--- a/src/process/clearHidden.ts
+++ b/src/process/clearHidden.ts
@@ -21,8 +21,9 @@ export const clearHiddenProcess: ProcessorFnSync<ClearHiddenScope> = (context) =
     if (!scope.clearHidden) {
         scope.clearHidden = {};
     }
+    //conditional path is a partial path, check to see if in the path
     const conditionallyHidden = (scope as ConditionsScope).conditionals?.find((cond) => {
-        return cond.path === path;
+        return path.includes(cond.path);
     });
     if (
         conditionallyHidden?.conditionallyHidden &&

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -12,15 +12,6 @@ import {
     isJSONConditional
 } from 'utils/conditions';
 
-const skipOnServer = (context: ConditionsContext): boolean => {
-    const { component, config } = context;
-    const clearOnHide = component.hasOwnProperty('clearOnHide') ? component.clearOnHide : true;
-    if (config?.server && !clearOnHide) {
-        // No need to run conditionals on server unless clearOnHide is set.
-        return true;
-    }
-    return false;
-};
 
 const hasCustomConditions = (context: ConditionsContext): boolean => {
     const { component } = context;
@@ -100,10 +91,6 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
     if (!conditionalComp) {
         conditionalComp = {path, conditionallyHidden: false};
         scope.conditionals.push(conditionalComp);
-    }
-
-    if (skipOnServer(context)) {
-        return false;
     }
 
     conditionalComp.conditionallyHidden = conditionalComp.conditionallyHidden || isHidden(context);

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -100,6 +100,7 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
             // If this is a container component, we need to add all the child components as conditionally hidden as well.
             Utils.eachComponentData([component], row, (comp: Component, data: any, compRow: any, compPath: string) => {
                 if (comp !== component) {
+                    // the path set here is not the absolute path, but the path relative to the parent component
                     scope.conditionals?.push({ path: getComponentPath(comp, compPath), conditionallyHidden: true });
                 }
                 set(comp, 'hidden', true);


### PR DESCRIPTION

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8537

## Description
The issue was that fields that should have been hidden on the submission were

**What changed?**

 two things changed:
1. in the `conditionalProcess` function there was a check to see if clearOnHide was checked before setting the conditional fields in the context scope.  This was removed.
2. In the `clearHiddenProcess` function, the path in the conditional scope entries were checking the complete path of the component to determine if the submission data should be removed.  However, the path being set in scope conditional array is a relative path from the parent, and therefore skipped.  The change was to do a partial match on the conditional path to see if it should be omitted.
3. 


## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

None

## How has this PR been tested?
unit tests

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:


- [ x] I have completed the above PR template
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x ] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
