### PR TITLE
FIO-8626: Updated conditionally hidden logic

### DIFF
--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -48,11 +48,10 @@ export function setActionBooleanProperty(context: LogicContext, action: LogicAct
     if (currentValue !== newValue) {
         set(component, property, newValue === 'true');
 
-        // If this is "logic" forcing a component to be hidden, then we will set the "conditionallyHidden"
+        // If this is "logic" forcing a component to set hidden property, then we will set the "conditionallyHidden"
         // flag which will trigger the clearOnHide functionality.
         if (
             property === 'hidden' &&
-            component.hidden &&
             path
         ) {
             if (!(scope as any).conditionals) {
@@ -62,12 +61,12 @@ export function setActionBooleanProperty(context: LogicContext, action: LogicAct
                 return cond.path === path
             });
             if (conditionalyHidden) {
-                conditionalyHidden.conditionallyHidden = true;
+                conditionalyHidden.conditionallyHidden = component.hidden;
             }
             else {
                 (scope as any).conditionals.push({
                     path,
-                    conditionallyHidden: true
+                    conditionallyHidden: component.hidden,
                 });
             }
         }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8626

## Description

`@formio/vm` relies on conditionally hidden components to render the email correctly. Previously, we tracked only conditionals that come from logic and set the `hidden` property to `true`. However, we also need to handle the opposite operation, where a component is hidden but logic sets the `hidden` property to `false`.

## How has this PR been tested?

Unit tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
