### PR TITLE
FIO-8731: Update fix to nested hidden components

### DIFF
--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -1,7 +1,6 @@
 import { ProcessorFn, ProcessorFnSync, ConditionsScope, ProcessorInfo, ConditionsContext, SimpleConditional, JSONConditional, LegacyConditional, SimpleConditionalConditions, Component, NestedComponent, FilterScope } from 'types';
-import { Utils } from 'utils';
 import { set } from 'lodash';
-import { componentInfo, getComponentKey, getComponentPath } from 'utils/formUtil';
+import { componentInfo, eachComponentData, getComponentPath } from 'utils/formUtil';
 import {
     checkCustomConditional,
     checkJsonConditional,
@@ -80,7 +79,7 @@ export const isConditionallyHidden = (context: ConditionsContext): boolean => {
 export type ConditionallyHidden = (context: ConditionsContext) => boolean;
 
 export const conditionalProcess = (context: ConditionsContext, isHidden: ConditionallyHidden) => {
-    const { component, data, row, scope, path } = context;
+    const { component, row, scope, path } = context;
     if (!hasConditions(context)) {
         return;
     }
@@ -95,20 +94,7 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
 
     conditionalComp.conditionallyHidden = conditionalComp.conditionallyHidden || isHidden(context);
     if (conditionalComp.conditionallyHidden) {
-        const info = componentInfo(component);
-        if (info.hasColumns || info.hasComps || info.hasRows) {
-            // If this is a container component, we need to add all the child components as conditionally hidden as well.
-            Utils.eachComponentData([component], row, (comp: Component, data: any, compRow: any, compPath: string) => {
-                if (comp !== component) {
-                    // the path set here is not the absolute path, but the path relative to the parent component
-                    scope.conditionals?.push({ path: getComponentPath(comp, compPath), conditionallyHidden: true });
-                }
-                set(comp, 'hidden', true);
-            });
-        }
-        else {
-            set(component, 'hidden', true);
-        }
+        set(component, 'hidden', true);
     }
 };
 

--- a/src/process/hiddenChildren.ts
+++ b/src/process/hiddenChildren.ts
@@ -1,0 +1,56 @@
+import { set } from 'lodash';
+import {
+    ProcessorScope,
+    ProcessorContext,
+    ProcessorInfo,
+    ProcessorFnSync,
+    ConditionsScope,
+    Component,
+    ProcessorFn,
+} from "types";
+import { componentInfo, eachComponentData, getComponentPath } from 'utils/formUtil';
+
+/**
+ * This processor function checks components for the `hidden` property and, if children are present, sets them to hidden as well.
+ */
+export const hiddenChildrenProcessor: ProcessorFnSync<ConditionsScope> = (context) => {
+    const { component, path, row, scope } = context;
+    // Check if there's a conditional set for the component and if it's marked as conditionally hidden
+    const isConditionallyHidden = scope.conditionals?.find((cond) => {
+        return path.includes(cond.path) && cond.conditionallyHidden;
+    });
+    if (component.hidden && isConditionallyHidden) {
+        const info = componentInfo(component);
+        if (info.hasColumns || info.hasComps || info.hasRows) {
+            // If this is a container component, we need to make the mutation to all the child components as well.
+            eachComponentData([component], row, (comp: Component, data: any, compRow: any, compPath: string) => {
+                if (comp !== component) {
+                    // the path set here is not the absolute path, but the path relative to the parent component
+                    (scope as ConditionsScope).conditionals?.push({ path: getComponentPath(comp, compPath), conditionallyHidden: true });
+                    set(comp, 'hidden', true);
+                }
+            });
+        }
+    } else if (component.hidden) {
+        const info = componentInfo(component);
+        if (info.hasColumns || info.hasComps || info.hasRows) {
+            // If this is a container component, we need to make the mutation to all the child components as well.
+            eachComponentData([component], row, (comp: Component, data: any, compRow: any, compPath: string) => {
+                if (comp !== component) {
+                    set(comp, 'hidden', true);
+                }
+            });
+        }
+    }
+}
+
+export const hiddenChildrenProcessorAsync: ProcessorFn<ProcessorScope> = async (context) => {
+    return hiddenChildrenProcessor(context);
+};
+
+export const hiddenChildrenProcessorInfo: ProcessorInfo<ProcessorContext<ProcessorScope>, void> = {
+    name: 'hiddenChildren',
+    shouldProcess: () => true,
+    processSync: hiddenChildrenProcessor,
+    process: hiddenChildrenProcessorAsync,
+}

--- a/src/process/hideChildren.ts
+++ b/src/process/hideChildren.ts
@@ -13,7 +13,7 @@ import { componentInfo, eachComponentData, getComponentPath } from 'utils/formUt
 /**
  * This processor function checks components for the `hidden` property and, if children are present, sets them to hidden as well.
  */
-export const hiddenChildrenProcessor: ProcessorFnSync<ConditionsScope> = (context) => {
+export const hideChildrenProcessor: ProcessorFnSync<ConditionsScope> = (context) => {
     const { component, path, row, scope } = context;
     // Check if there's a conditional set for the component and if it's marked as conditionally hidden
     const isConditionallyHidden = scope.conditionals?.find((cond) => {
@@ -44,13 +44,13 @@ export const hiddenChildrenProcessor: ProcessorFnSync<ConditionsScope> = (contex
     }
 }
 
-export const hiddenChildrenProcessorAsync: ProcessorFn<ProcessorScope> = async (context) => {
-    return hiddenChildrenProcessor(context);
+export const hideChildrenProcessorAsync: ProcessorFn<ProcessorScope> = async (context) => {
+    return hideChildrenProcessor(context);
 };
 
-export const hiddenChildrenProcessorInfo: ProcessorInfo<ProcessorContext<ProcessorScope>, void> = {
-    name: 'hiddenChildren',
+export const hideChildrenProcessorInfo: ProcessorInfo<ProcessorContext<ProcessorScope>, void> = {
+    name: 'hideChildren',
     shouldProcess: () => true,
-    processSync: hiddenChildrenProcessor,
-    process: hiddenChildrenProcessorAsync,
+    processSync: hideChildrenProcessor,
+    process: hideChildrenProcessorAsync,
 }

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -11,4 +11,4 @@ export * from './process';
 export * from './normalize';
 export * from './dereference';
 export * from './clearHidden';
-export * from './hiddenChildren'
+export * from './hideChildren';

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -10,3 +10,5 @@ export * from './processOne';
 export * from './process';
 export * from './normalize';
 export * from './dereference';
+export * from './clearHidden';
+export * from './hiddenChildren'

--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -28,7 +28,7 @@ import { filterProcessInfo } from './filter';
 import { normalizeProcessInfo } from './normalize';
 import { dereferenceProcessInfo } from './dereference';
 import { clearHiddenProcessInfo } from './clearHidden';
-import { hiddenChildrenProcessorInfo } from './hiddenChildren';
+import { hideChildrenProcessorInfo } from './hideChildren';
 
 export async function process<ProcessScope>(
   context: ProcessContext<ProcessScope>
@@ -131,7 +131,7 @@ export const ProcessorMap: Record<string, ProcessorInfo<any, any>> = {
   validate: validateProcessInfo,
   validateCustom: validateCustomProcessInfo,
   validateServer: validateServerProcessInfo,
-  hiddenChildren: hiddenChildrenProcessorInfo
+  hideChildren: hideChildrenProcessorInfo
 };
 
 export const ProcessTargets: ProcessTarget = {
@@ -149,7 +149,7 @@ export const ProcessTargets: ProcessTarget = {
     calculateProcessInfo,
     logicProcessInfo,
     conditionProcessInfo,
-    hiddenChildrenProcessorInfo,
+    hideChildrenProcessorInfo,
     clearHiddenProcessInfo,
     validateProcessInfo,
   ],

--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -1,5 +1,3 @@
-import get from 'lodash/get';
-import set from 'lodash/set';
 import {
   ProcessContext,
   ProcessTarget,
@@ -30,6 +28,7 @@ import { filterProcessInfo } from './filter';
 import { normalizeProcessInfo } from './normalize';
 import { dereferenceProcessInfo } from './dereference';
 import { clearHiddenProcessInfo } from './clearHidden';
+import { hiddenChildrenProcessorInfo } from './hiddenChildren';
 
 export async function process<ProcessScope>(
   context: ProcessContext<ProcessScope>
@@ -132,6 +131,7 @@ export const ProcessorMap: Record<string, ProcessorInfo<any, any>> = {
   validate: validateProcessInfo,
   validateCustom: validateCustomProcessInfo,
   validateServer: validateServerProcessInfo,
+  hiddenChildren: hiddenChildrenProcessorInfo
 };
 
 export const ProcessTargets: ProcessTarget = {
@@ -149,6 +149,7 @@ export const ProcessTargets: ProcessTarget = {
     calculateProcessInfo,
     logicProcessInfo,
     conditionProcessInfo,
+    hiddenChildrenProcessorInfo,
     clearHiddenProcessInfo,
     validateProcessInfo,
   ],

--- a/src/process/validation/index.ts
+++ b/src/process/validation/index.ts
@@ -115,8 +115,6 @@ export const _shouldSkipValidation = (context: ValidationContext, isConditionall
       () => isValueHidden(context),
       // Force valid if component is hidden.
       () => isForcedHidden(context, isConditionallyHidden) && !validateWhenHidden,
-      // Do not validate if 'validateWhenHidden' is disabled and some component parent is hidden
-      () => !validateWhenHidden && isParentHidden(component),
     ];
 
     return rules.some(pred => pred());;

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -288,12 +288,6 @@ export const eachComponentDataAsync = async (
         }
         return true;
       }
-      // This way layout components are added as parents to the child components
-      if (isComponentModelType(component, 'layout')) {
-        await eachComponentDataAsync(component.components, data, fn, componentDataPath(component, path, compPath), index, component, includeAll);
-        return true;
-      }
-
       return false;
     },
     true,
@@ -345,12 +339,6 @@ export const eachComponentData = (
         else {
           eachComponentData(component.components, data, fn, componentDataPath(component, path, compPath), index, component, includeAll);
         }
-        return true;
-      }
-
-      // This way layout components are added as parents to the child components
-      if (isComponentModelType(component, 'layout')) {
-        eachComponentData(component.components, data, fn, componentDataPath(component, path, compPath), index, component, includeAll);
         return true;
       }
 

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -1,8 +1,9 @@
-import { ConditionsScope, LogicContext, ProcessorContext } from "types";
+import { Component, ConditionsScope, LogicContext, ProcessorContext } from "types";
 import { checkCustomConditional, checkJsonConditional, checkLegacyConditional, checkSimpleConditional, conditionallyHidden, isLegacyConditional } from "./conditions";
 import { LogicActionCustomAction, LogicActionMergeComponentSchema, LogicActionProperty, LogicActionPropertyBoolean, LogicActionPropertyString, LogicActionValue } from "types/AdvancedLogic";
 import { get, set, clone, isEqual, assign } from 'lodash';
 import { evaluate, interpolate } from 'modules/jsonlogic';
+import { componentInfo, eachComponentData, getComponentPath } from "./formUtil";
 
 export const hasLogic = (context: LogicContext): boolean => {
     const { component } = context;
@@ -41,7 +42,7 @@ export const checkTrigger = (context: LogicContext, trigger: any): boolean => {
 };
 
 export function setActionBooleanProperty(context: LogicContext, action: LogicActionPropertyBoolean): boolean {
-    const { component, scope, path } = context;
+    const { component, scope, path, row } = context;
     const property = action.property.value;
     const currentValue = get(component, property, false).toString();
     const newValue = action.state.toString();
@@ -54,21 +55,22 @@ export function setActionBooleanProperty(context: LogicContext, action: LogicAct
             property === 'hidden' &&
             path
         ) {
-            if (!(scope as any).conditionals) {
-                (scope as any).conditionals = [];
+            if (!(scope as ConditionsScope).conditionals) {
+                (scope as ConditionsScope).conditionals = [];
             }
-            const conditionalyHidden = (scope as any).conditionals.find((cond: any) => {
+            const conditionalyHidden = (scope as ConditionsScope).conditionals?.find((cond: any) => {
                 return cond.path === path
             });
             if (conditionalyHidden) {
-                conditionalyHidden.conditionallyHidden = component.hidden;
+                conditionalyHidden.conditionallyHidden = !!component.hidden;
             }
             else {
-                (scope as any).conditionals.push({
+                (scope as ConditionsScope).conditionals?.push({
                     path,
-                    conditionallyHidden: component.hidden,
+                    conditionallyHidden: !!component.hidden,
                 });
             }
+            set(component, 'hidden', !!component.hidden);
         }
         return true;
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8731

## Description

This commit: 
* reverts adding layout component logical branch to eachComponentData
* reverts the isParent check in validation subroutine
* adds a hiddenChildren processor to core that adds hidden properties to children

This is _not the most ideal solution_ for two reasons: 

(a) it continues ad-hoc iteration over the components tree, which has the potential to be a bottleneck in situations where there are many levels of nested hidden components (there is no mechanism to avoid repeating the hiddenChildren processor).  It would better to eliminate this ad-hoc iteration entirely to go with some approach that allowed processors to pass values down to child nested components. (Note that we were already doing this, this PR just codifies it into its own processor.)

(b) Although less of a concern, I can imagine a scenario in which some logic in some deeply nested component actually _un-hides_  the child components, in which case you could potentially run into a scenario where the grand parent component is hidden but one or more children are un-hidden.

However, this issue is blocking a major release, so I propose that we merge this change and file a tech-debt ticket to resolve this issue in a better way.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Automated tests added for the previous solution for this ticket pass, as well as upstream OSS formio tests.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
