### PR TITLE
FIO-8778: add case for map component model type in filter; add tests

### DIFF
--- a/src/process/__tests__/fixtures/util.ts
+++ b/src/process/__tests__/fixtures/util.ts
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
-import { ProcessorContext, ProcessorScope, Component } from 'types';
-export const generateProcessorContext = (component: Component, data: any): ProcessorContext<ProcessorScope> => {
+import { ProcessorContext, Component } from 'types';
+export const generateProcessorContext = <ProcessorScope>(component: Component, data: any): ProcessorContext<ProcessorScope> => {
     return {
         component,
         path: component.key,

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -4,7 +4,6 @@ import type { ContainerComponent, ValidationScope } from 'types';
 import { getComponent } from 'utils/formUtil';
 import { process, processSync, ProcessTargets } from '../index';
 import { clearOnHideWithCustomCondition, clearOnHideWithHiddenParent, skipValidForConditionallyHiddenComp, skipValidForLogicallyHiddenComp, skipValidWithHiddenParentComp  } from './fixtures'
-import components from 'src/experimental/components/index.js';
 /*
 describe('Process Tests', () => {
     it('Should perform the processes using the processReduced method.', async () => {

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -4,6 +4,7 @@ import type { ContainerComponent, ValidationScope } from 'types';
 import { getComponent } from 'utils/formUtil';
 import { process, processSync, ProcessTargets } from '../index';
 import { clearOnHideWithCustomCondition, clearOnHideWithHiddenParent, skipValidForConditionallyHiddenComp, skipValidForLogicallyHiddenComp, skipValidWithHiddenParentComp  } from './fixtures'
+import components from 'src/experimental/components/index.js';
 /*
 describe('Process Tests', () => {
     it('Should perform the processes using the processReduced method.', async () => {
@@ -2780,6 +2781,57 @@ describe('Process Tests', () => {
     });
   });
 
+  it('Should not filter a simple datamap compoennt', async () => {
+    const form = {
+      display: 'form',
+      components: [
+        {
+          label: "Data Map",
+          tableView: false,
+          validateWhenHidden: false,
+          key: "dataMap",
+          type: "datamap",
+          path: "dataMap",
+          input: true,
+          valueComponent: {
+            type: "textfield",
+            key: "value",
+            label: "Value",
+            input: true,
+            hideLabel: true,
+            tableView: true,
+          },
+        }
+      ]
+    };
+    const submission = {
+      data: {
+        dataMap: {
+          key1: "value1",
+          key2: "value2"
+        }
+      }
+    };
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.evaluator,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    expect(context.data).to.deep.equal({
+      dataMap: {
+        key1: "value1",
+        key2: "value2"
+      }
+    });
+  })
+
   describe('Required component validation in nested form in DataGrid/EditGrid', () => {
     const nestedForm = {
       key: 'form',
@@ -3147,6 +3199,7 @@ describe('Process Tests', () => {
 
     });
   });
+
   /*
           it('Should not clearOnHide when set to false', async () => {
             var components = [

--- a/src/process/filter/__tests__/filter.test.ts
+++ b/src/process/filter/__tests__/filter.test.ts
@@ -1,73 +1,116 @@
-import { expect } from 'chai';
+import { expect } from "chai";
 
-import { filterProcessSync } from '../';
-import { generateProcessorContext } from '../../__tests__/fixtures/util';
+import { filterProcessSync } from "../";
+import { generateProcessorContext } from "../../__tests__/fixtures/util";
+import { FilterScope, ProcessorContext } from "types";
 
-it('Should not filter empty array value for dataGrid component', async () => {
-    const dataGridComp = {
-        type: 'datagrid',
-        key: 'dataGrid',
+it("Should not filter empty array value for dataGrid component", async () => {
+  const dataGridComp = {
+    type: "datagrid",
+    key: "dataGrid",
+    input: true,
+    path: "dataGrid",
+    components: [
+      {
+        type: "textfield",
+        key: "textField",
         input: true,
-        path: 'dataGrid',
-        components: [
-            {
-                type: 'textfield',
-                key: 'textField',
-                input: true,
-                label: 'Text Field'
-            }
-        ]
-    };
-    const data = {
-        dataGrid: []
-    };
-    const context: any = generateProcessorContext(dataGridComp, data);
-    filterProcessSync(context);
-    expect(context.scope.filter).to.deep.equal({'dataGrid': {'compModelType': 'array', 'include': true, value: []}});
+        label: "Text Field",
+      },
+    ],
+  };
+  const data = {
+    dataGrid: [],
+  };
+  const context: any = generateProcessorContext(dataGridComp, data);
+  filterProcessSync(context);
+  expect(context.scope.filter).to.deep.equal({
+    dataGrid: { compModelType: "array", include: true, value: [] },
+  });
 });
 
-it('Should not filter empty array value for editGrid component', async () => {
-    const editGridComp = {
-        type: 'editgrid',
-        key: 'editGrid',
+it("Should not filter empty array value for editGrid component", async () => {
+  const editGridComp = {
+    type: "editgrid",
+    key: "editGrid",
+    input: true,
+    path: "editGrid",
+    components: [
+      {
+        type: "textfield",
+        key: "textField",
         input: true,
-        path: 'editGrid',
-        components: [
-            {
-                type: 'textfield',
-                key: 'textField',
-                input: true,
-                label: 'Text Field'
-            }
-        ]
-    };
-    const data = {
-        editGrid: []
-    };
-    const context: any = generateProcessorContext(editGridComp, data);
-    filterProcessSync(context);
-    expect(context.scope.filter).to.deep.equal({'editGrid': {'compModelType': 'array', 'include': true, value: []}});
+        label: "Text Field",
+      },
+    ],
+  };
+  const data = {
+    editGrid: [],
+  };
+  const context: any = generateProcessorContext(editGridComp, data);
+  filterProcessSync(context);
+  expect(context.scope.filter).to.deep.equal({
+    editGrid: { compModelType: "array", include: true, value: [] },
+  });
 });
 
-it('Should not filter empty array value for datTable component', async () => {
-    const dataTableComp = {
-        type: 'datatable',
-        key: 'dataTable',
+it("Should not filter empty array value for dataTable component", async () => {
+  const dataTableComp = {
+    type: "datatable",
+    key: "dataTable",
+    input: true,
+    path: "dataTable",
+    components: [
+      {
+        type: "textfield",
+        key: "textField",
         input: true,
-        path: 'dataTable',
-        components: [
-            {
-                type: 'textfield',
-                key: 'textField',
-                input: true,
-                label: 'Text Field'
-            }
-        ]
-    };
-    const data = {
-        dataTable: []
-    };
-    const context: any = generateProcessorContext(dataTableComp, data);
-    filterProcessSync(context);
-    expect(context.scope.filter).to.deep.equal({'dataTable': {'compModelType': 'array', 'include': true, value: []}});
+        label: "Text Field",
+      },
+    ],
+  };
+  const data = {
+    dataTable: [],
+  };
+  const context: any = generateProcessorContext(dataTableComp, data);
+  filterProcessSync(context);
+  expect(context.scope.filter).to.deep.equal({
+    dataTable: { compModelType: "array", include: true, value: [] },
+  });
+});
+
+it("Should not filter the datamap component", async () => {
+  const dataMapComp = {
+    label: "Data Map",
+    tableView: false,
+    validateWhenHidden: false,
+    key: "dataMap",
+    type: "datamap",
+    path: "dataMap",
+    input: true,
+    valueComponent: {
+      type: "textfield",
+      key: "value",
+      label: "Value",
+      input: true,
+      hideLabel: true,
+      tableView: true,
+    },
+  };
+
+  const data = {
+    dataMap: {
+        foo: "bar",
+        baz: "biz"
+    },
+  };
+
+  const context: ProcessorContext<FilterScope> = generateProcessorContext(dataMapComp, data);
+  filterProcessSync(context);
+  expect(context.scope.filter).to.deep.equal({
+    dataMap: {
+      compModelType: "map",
+      include: true,
+    }
+  });
 });

--- a/src/process/normalize/__tests__/normalize.test.ts
+++ b/src/process/normalize/__tests__/normalize.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { TimeComponent, SelectBoxesComponent } from 'types';
+import { TimeComponent, SelectBoxesComponent, ProcessorContext, ProcessorScope } from 'types';
 import { normalizeProcessSync } from '../';
 import { generateProcessorContext } from '../../__tests__/fixtures/util';
 
@@ -13,7 +13,7 @@ it('Should normalize a time component with a valid time value that doees not mat
     dataFormat: 'HH:mm:ss',
   };
   const data = { time: '12:00' };
-  const context = generateProcessorContext(timeComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(timeComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ time: '12:00:00' });
 });
@@ -33,7 +33,7 @@ it('Should normalize a select boxes component with an incorrect data model', () 
   const data = {
     selectBoxes: '',
   };
-  const context = generateProcessorContext(selectBoxesComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(selectBoxesComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ selectBoxes: {} });
 });
@@ -48,7 +48,7 @@ it('Should normalize an email component value', () => {
   const data = {
     email: 'BrendanBond@Gmail.com',
   };
-  const context = generateProcessorContext(emailComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(emailComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ email: 'brendanbond@gmail.com' });
 });
@@ -73,7 +73,7 @@ it('Should normalize a radio component with a string value', () => {
   const data = {
     radio: 'true',
   };
-  const context = generateProcessorContext(radioComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(radioComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ radio: true });
 });
@@ -97,7 +97,7 @@ it('Should normalize a radio component with a string value of false', () => {
   const data = {
     radio: 'false',
   };
-  const context = generateProcessorContext(radioComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(radioComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ radio: false });
 });
@@ -122,7 +122,7 @@ it('Should normalize a radio component value with a number', () => {
   const data = {
     radio: '0',
   };
-  const context = generateProcessorContext(radioComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(radioComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ radio: 0 });
 });
@@ -148,7 +148,7 @@ it('Should normalize a radio component value with a string if storage type is se
   const data = {
     radio: 0,
   };
-  const context = generateProcessorContext(radioComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(radioComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ radio: '0' });
 });
@@ -173,7 +173,7 @@ it('Should normalize a radio component value with a number if storage type is se
   const data = {
     radio: 1,
   };
-  const context = generateProcessorContext(radioComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(radioComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ radio: 1 });
 });
@@ -198,7 +198,7 @@ it('Should normalize a radio component value with a boolean if storage type is s
   const data = {
     radio: true,
   };
-  const context = generateProcessorContext(radioComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(radioComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ radio: true });
 });
@@ -223,7 +223,7 @@ it('Should normalize a radio component value with a false boolean if storage typ
   const data = {
     radio: 'false',
   };
-  const context = generateProcessorContext(radioComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(radioComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ radio: false });
 });
@@ -249,7 +249,7 @@ it('Should normalize a radio component value with an object  if storage type is 
   const data = {
     radio: { test: 'test' },
   };
-  const context = generateProcessorContext(radioComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(radioComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({
     radio: JSON.stringify({ test: 'test' }),
@@ -266,7 +266,7 @@ it('Should normalize a number component value with a string value', () => {
   const data = {
     number: '000123',
   };
-  const context = generateProcessorContext(numberComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(numberComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ number: 123 });
 });
@@ -282,7 +282,7 @@ it('Should normalize a number component value with a multiple values allowed', (
   const data = {
     number: ['000.0123', '123'],
   };
-  const context = generateProcessorContext(numberComp, data);
+  const context: ProcessorContext<ProcessorScope> = generateProcessorContext(numberComp, data);
   normalizeProcessSync(context);
   expect(context.data).to.deep.equal({ number: [0.0123, 123] });
 });

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -144,6 +144,9 @@ export function getModelType(component: Component) {
     if (isComponentModelType(component, 'array')) {
       return 'array';
     }
+    if (isComponentModelType(component, 'map')) {
+      return 'map';
+    }
     return 'object';
   }
   if ((component.input === false) || isComponentModelType(component, 'layout')) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8778

## Description

The filter process was not accounting for "map" model types, which resemble "object" model types but crucially don't have child components (or at least, child components that get iterated into). This PR updates the getModelType function to account for the "map" model type.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Added some automated tests.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
