### PR TITLE
FIO-8848 fixed validation for TextArea with Save as Json

### DIFF
--- a/src/process/validation/rules/__tests__/validateMultiple.test.ts
+++ b/src/process/validation/rules/__tests__/validateMultiple.test.ts
@@ -34,7 +34,7 @@ describe('validateMultiple', () => {
             expect(isEligible(component)).to.be.true;
         });
 
-        it('should return false for textArea component with as !== json', () => {
+        it('should return false for textArea component with as !== json if multiple', () => {
             const component: TextAreaComponent = {
                 type: 'textarea',
                 as: 'text',
@@ -50,9 +50,9 @@ describe('validateMultiple', () => {
             expect(isEligible(component)).to.be.false;
         });
 
-        it('should return true for textArea component with as === json', () => {
+        it('should return true for textArea component with as === json if multiple', () => {
             const component: TextAreaComponent = {
-                type: 'textArea',
+                type: 'textarea',
                 as: 'json',
                 input: true,
                 key: 'textAreaJson',
@@ -64,6 +64,21 @@ describe('validateMultiple', () => {
                 inputFormat: 'plain',
             };
             expect(isEligible(component)).to.be.true;
+        });
+
+        it('should return false for textArea component with as === json if not multiple', () => {
+            const component: TextAreaComponent = {
+                type: 'textarea',
+                as: 'json',
+                input: true,
+                key: 'textAreaJson',
+                rows: 4,
+                wysiwyg: true,
+                editor: 'ace',
+                fixedSize: true,
+                inputFormat: 'plain',
+            };
+            expect(isEligible(component)).to.be.false;
         });
 
         it('should return true for other component types', () => {

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -22,7 +22,8 @@ export const isEligible = (component: Component) => {
     case 'textarea':
       if (
         !(component as TextAreaComponent).as ||
-        (component as TextAreaComponent).as !== 'json'
+        (component as TextAreaComponent).as !== 'json' ||
+        ((component as TextAreaComponent).as === 'json' && !component.multiple)
       ) {
         return false;
       }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8848

## Description

*Fixed an issue with saving a value for non multiple Text Area componentl if the "Save as" property is set to "json". Previously, if non multiple Text Area with 'Save As'= 'json' was filled in as an array, 'nonarray' Error was displayed. This caused regression when it was not possible to save Select component with Data Source Type Raw JSON. This has been fixed by adding an additional condition for validateMultiple*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated test has been added*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
