### PR TITLE
FIO-8810: fixed an issue where user unables to resubmit (change) the form with several levels of nested forms with required fields

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -2831,6 +2831,103 @@ describe('Process Tests', () => {
     });
   })
 
+  it('Should allow the submission to go through without errors if there is no the subform reference value', async () => {
+    const form =  {
+      _id: '66bc5cff7ca1729623a182db',
+      title: 'form2',
+      name: 'form2',
+      path: 'form2',
+      type: 'resource',
+      display: 'form',
+      owner: '637b2e6b48c1227e60b1f910',
+      components: [
+        {
+          label: 'Text Field - form2',
+          applyMaskOn: 'change',
+          tableView: true,
+          validate: { required: true },
+          validateWhenHidden: false,
+          key: 'textFieldForm2',
+          type: 'textfield',
+          input: true,
+        },
+        {
+          label: 'Form',
+          tableView: true,
+          form: '66bc5ccd7ca1729623a18063',
+          useOriginalRevision: false,
+          key: 'form',
+          type: 'form',
+          input: true,
+          components: [
+            {
+              label: 'Text Field form1',
+              applyMaskOn: 'change',
+              tableView: true,
+              validate: { required: true },
+              validateWhenHidden: false,
+              key: 'textFieldForm1',
+              type: 'textfield',
+              input: true,
+            },
+            {
+              type: 'button',
+              label: 'Submit',
+              key: 'submit',
+              disableOnInvalid: true,
+              input: true,
+              tableView: false,
+            },
+          ],
+        },
+        {
+          type: 'button',
+          label: 'Submit',
+          key: 'submit',
+          disableOnInvalid: true,
+          input: true,
+          tableView: false,
+        },
+      ],
+      project: '669e1c67a40e327e67e7ce55',
+      _vid: 0,
+      esign: {},
+      created: '2024-08-14T07:30:07.953Z',
+      modified: '2024-08-14T10:09:13.201Z',
+      machineName: 'qzdhayddccjauyr:form2',
+      __v: 1,
+    };
+
+    const submission = {
+      data: { textFieldForm2: '1', form: { _id: '66c455fc0f00757fd4b0e79b' } },
+      owner: '637b2e6b48c1227e60b1f910',
+      access: [],
+      _fvid: 0,
+      state: 'submitted',
+      _id: '66c455fc0f00757fd4b0e79d',
+      form: '66bc5cff7ca1729623a182db',
+    };
+
+    const errors: any = [];
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.submission,
+      scope: { errors },
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    processSync(context);
+    assert.equal(context.scope.errors.length, 0);
+    assert.deepEqual(context.data.form, { _id: '66c455fc0f00757fd4b0e79b', data: {} })
+  });
+
   describe('Required component validation in nested form in DataGrid/EditGrid', () => {
     const nestedForm = {
       key: 'form',

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -280,8 +280,8 @@ export const eachComponentDataAsync = async (
         if (isComponentModelType(component, 'dataObject')) {
           // No need to bother processing all the children data if there is no data for this form or the reference value has not been loaded.
           const nestedFormValue: any = get(data, component.path);
-          const noReferenceAttached = nestedFormValue && nestedFormValue._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
-          const shouldProcessNestedFormData = nestedFormValue && nestedFormValue._id ? !noReferenceAttached : has(data, component.path);
+          const noReferenceAttached = nestedFormValue?._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
+          const shouldProcessNestedFormData = nestedFormValue?._id ? !noReferenceAttached : has(data, component.path);
           if (shouldProcessNestedFormData) {
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
             const childPath: string = componentDataPath(component, path, compPath);

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -336,7 +336,7 @@ export const eachComponentData = (
         if (isComponentModelType(component, 'dataObject')) {
           // No need to bother processing all the children data if there is no data for this form or the reference value has not been loaded.
           const nestedFormValue: any = get(data, component.path);
-          const noReferenceAttached =nestedFormValue?._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
+          const noReferenceAttached = nestedFormValue?._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
           const shouldProcessNestedFormData = nestedFormValue?._id ? !noReferenceAttached : has(data, component.path);
           if (shouldProcessNestedFormData) {
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -336,8 +336,8 @@ export const eachComponentData = (
         if (isComponentModelType(component, 'dataObject')) {
           // No need to bother processing all the children data if there is no data for this form or the reference value has not been loaded.
           const nestedFormValue: any = get(data, component.path);
-          const noReferenceAttached = nestedFormValue && nestedFormValue._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
-          const shouldProcessNestedFormData = nestedFormValue && nestedFormValue._id ? !noReferenceAttached : has(data, component.path);
+          const noReferenceAttached =nestedFormValue?._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
+          const shouldProcessNestedFormData = nestedFormValue?._id ? !noReferenceAttached : has(data, component.path);
           if (shouldProcessNestedFormData) {
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
             const childPath: string = componentDataPath(component, path, compPath);

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -278,8 +278,11 @@ export const eachComponentDataAsync = async (
           return true;
         }
         if (isComponentModelType(component, 'dataObject')) {
-          // No need to bother processing all the children data if there is no data for this form.
-          if (has(data, component.path)) {
+          // No need to bother processing all the children data if there is no data for this form or the reference value has not been loaded.
+          const nestedFormValue: any = get(data, component.path);
+          const noReferenceAttached = nestedFormValue && nestedFormValue._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
+          const shouldProcessNestedFormData = nestedFormValue && nestedFormValue._id ? !noReferenceAttached : has(data, component.path);
+          if (shouldProcessNestedFormData) {
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
             const childPath: string = componentDataPath(component, path, compPath);
             const childData: any = get(data, childPath, null);
@@ -331,8 +334,11 @@ export const eachComponentData = (
           return true;
         }
         if (isComponentModelType(component, 'dataObject')) {
-          // No need to bother processing all the children data if there is no data for this form.
-          if (has(data, component.path)) {
+          // No need to bother processing all the children data if there is no data for this form or the reference value has not been loaded.
+          const nestedFormValue: any = get(data, component.path);
+          const noReferenceAttached = nestedFormValue && nestedFormValue._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
+          const shouldProcessNestedFormData = nestedFormValue && nestedFormValue._id ? !noReferenceAttached : has(data, component.path);
+          if (shouldProcessNestedFormData) {
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
             const childPath: string = componentDataPath(component, path, compPath);
             const childData: any = get(data, childPath, {});


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8810

## Description

**What changed?**

Sometimes the submission, that we pass to validator, does not have reference data for nested forms. The value of such nested forms looks like this { id: 'someID', data: {} }.  I found at least 2 cases when it happens for PUT requests:
1) when we want to change the submission of wizard form that have at least 1 page in the middle of the wizard with deeply nested forms. In this case the user can open 1st page and make changes, then go to the last page to submit the form. The middle page with deeply nested forms is not opened, it means that the nested form submission data is not loaded (it is lazy loaded from level 3). So, the server gets the empty data (just with reference ID) for such nested form.
2) when we submit the webform with several levels of nested forms. In this case the full data (including all nested forms data) is validated as a part of the top form validation and then each nested form data(starting from the deepest one) is resaved. Once the deepest nested form value (No. 1) is resaved, the higher level nested form (No. 2) gets the form No.1 value as a reference to id without data. So, when the form No.2 is validated, its data does not have full submission object for form No. 1.

In both cases the submission data of deeply nested forms does not need the repeated validation: 
1) in case 1, the data of the deeply nested form is not changed and should not be resubmitted
2) in case 2, the data of the deeply nested form was validated as a part of the top form validation + validated when the subform data is resaved on the server.

Noting all said, I have added the logic for eachComponentData that skips the iteration through the nested form data when the reference value is not attached.

## Dependencies

https://github.com/formio/formio/pull/1784

## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
