### PR TITLE
FIO-8798: updated day component validation

### DIFF
--- a/src/process/validation/rules/__tests__/validateDay.test.ts
+++ b/src/process/validation/rules/__tests__/validateDay.test.ts
@@ -57,3 +57,73 @@ it('Validating a day component with a valid Date object will return a field erro
     expect(result).to.be.instanceOf(FieldError);
     expect(result?.errorKeyOrMessage).to.equal('invalidDay');
 });
+
+it('Validating a day component with hidden day field with an valid date string value will return null', async () => {
+    const component = simpleDayField;
+    component.fields.day.hide = true;
+    const data = {
+        component: '03/2023',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateDay(context);
+    expect(result).to.equal(null);
+});
+
+it('Validating a day component with hidden day field with invalid date will return a field error', async () => {
+    const component = simpleDayField;
+    component.fields.day.hide = true;
+    const data = {
+        component: '13/2023',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateDay(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.equal('invalidDay');
+});
+
+it('Validating a day component with hidden month field with an valid date string value will return null', async () => {
+    const component = simpleDayField;
+    component.fields.month.hide = true;
+    const data = {
+        component: '23/2023',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateDay(context);
+    expect(result).to.equal(null);
+});
+
+it('Validating a day component with hidden month field with invalid date will return a field error', async () => {
+    const component = simpleDayField;
+    component.fields.month.hide = true;
+    const data = {
+        component: '130/2023',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateDay(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.equal('invalidDay');
+});
+
+it('Validating a day component with hidden year field with an valid date string value will return null', async () => {
+    const component = simpleDayField;
+    component.fields.year.hide = true;
+    const data = {
+        component: '01/23',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateDay(context);
+    expect(result).to.equal(null);
+});
+
+it('Validating a day component with hidden year field with invalid date will return a field error', async () => {
+    const component = simpleDayField;
+    component.fields.year.hide = true;
+    const data = {
+        component: '13/23',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateDay(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.equal('invalidDay');
+});
+

--- a/src/process/validation/rules/validateDay.ts
+++ b/src/process/validation/rules/validateDay.ts
@@ -50,37 +50,37 @@ export const validateDay: RuleFn = async (context: ValidationContext) => {
 
 export const validateDaySync: RuleFnSync = (context: ValidationContext) => {
     const { component, value } = context;
-    if (!shouldValidate(context)) {
+    if (!shouldValidate(context) || !isDayComponent(component)) {
         return null;
     }
     const error = new FieldError('invalidDay', context, 'day');
     if (typeof value !== 'string') {
         return error;
     }
-    let [DAY, MONTH, YEAR] = (component as DayComponent).dayFirst ? [0, 1, 2] : [1, 0, 2];
+    let [DAY, MONTH, YEAR] = component.dayFirst ? [0, 1, 2] : [1, 0, 2];
     
     const values = value.split('/').map((x) => parseInt(x, 10));
     let day = values[DAY];
     let month = values[MONTH];
     let year = values[YEAR];
 
-    if(values.length !== 3) {
-        if((component as DayComponent).fields.day.hide) {
+    if (values.length !== 3) {
+        if (component.fields.day.hide) {
             MONTH = MONTH === 0 ? 0 : MONTH - 1;
             YEAR = YEAR - 1;
             day = 0;
             month = values[MONTH];
             year = values[YEAR];
-            
+
         };
-        if((component as DayComponent).fields.month.hide) {
+        if (component.fields.month.hide) {
             DAY = DAY === 0 ? 0 : DAY - 1;
             YEAR = YEAR - 1;
             day = values[DAY];
             month = 0;
             year = values[YEAR];
         };
-        if((component as DayComponent).fields.year.hide) {
+        if (component.fields.year.hide) {
             day = values[DAY];
             month = values[MONTH];
             year = 0;

--- a/src/process/validation/rules/validateDay.ts
+++ b/src/process/validation/rules/validateDay.ts
@@ -57,13 +57,38 @@ export const validateDaySync: RuleFnSync = (context: ValidationContext) => {
     if (typeof value !== 'string') {
         return error;
     }
-    const [DAY, MONTH, YEAR] = (component as DayComponent).dayFirst ? [0, 1, 2] : [1, 0, 2];
-    const values = value.split('/').map((x) => parseInt(x, 10)),
-        day = values[DAY],
-        month = values[MONTH],
-        year = values[YEAR],
-        maxDay = getDaysInMonthCount(month, year);
+    let [DAY, MONTH, YEAR] = (component as DayComponent).dayFirst ? [0, 1, 2] : [1, 0, 2];
+    
+    const values = value.split('/').map((x) => parseInt(x, 10));
+    let day = values[DAY];
+    let month = values[MONTH];
+    let year = values[YEAR];
 
+    if(values.length !== 3) {
+        if((component as DayComponent).fields.day.hide) {
+            MONTH = MONTH === 0 ? 0 : MONTH - 1;
+            YEAR = YEAR - 1;
+            day = 0;
+            month = values[MONTH];
+            year = values[YEAR];
+            
+        };
+        if((component as DayComponent).fields.month.hide) {
+            DAY = DAY === 0 ? 0 : DAY - 1;
+            YEAR = YEAR - 1;
+            day = values[DAY];
+            month = 0;
+            year = values[YEAR];
+        };
+        if((component as DayComponent).fields.year.hide) {
+            day = values[DAY];
+            month = values[MONTH];
+            year = 0;
+        };
+    }
+
+    const maxDay = getDaysInMonthCount(month, year);
+    
     if (isNaN(day) || day < 0 || day > maxDay) {
         return error;
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8798

## Description

Day component validation was changed.
The changes were caused by a change in the formation of the data string for the Day component with hidden fields.
if a element of the day component is hidden, it should be excluded from the string instead of populating with ‘00’ 
Examples (new years):  
day / year == ‘01/2024’ 
month / year =  ‘01/2024’ 
day / month  = ‘01/01’

## Breaking Changes / Backwards Compatibility


## How has this PR been tested?
autotests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
