### PR TITLE
FIO-8901: Fixed incorrect handling of excessive rows in nested array model

### DIFF
--- a/src/experimental/base/array/__tests__/ArrayComponent.test.ts
+++ b/src/experimental/base/array/__tests__/ArrayComponent.test.ts
@@ -52,23 +52,32 @@ describe('ArrayComponent', () => {
             {
                 firstName: 'Sally',
                 lastName: 'Thompson'
+            },
+            {
+                firstName: 'Jane',
+                lastName: 'Doe'
             }
         ];
         arrComp.dataValue = employees;
         assert.deepEqual(data, {employees: employees});
         assert.deepEqual(arrComp.dataValue, employees);
-        assert.equal(arrComp.rows.length, 2);
+        assert.equal(arrComp.rows.length, 3);
         assert.equal(arrComp.rows[0].length, 2);
         assert.equal(arrComp.rows[1].length, 2);
-        assert.equal(arrComp.components.length, 4);
+        assert.equal(arrComp.rows[2].length, 2);
+        assert.equal(arrComp.components.length, 6);
         assert.equal(arrComp.components[0].dataValue, 'Joe');
         assert.equal(arrComp.components[1].dataValue, 'Smith');
         assert.strictEqual(arrComp.rows[0][0], arrComp.components[0]);
         assert.strictEqual(arrComp.rows[0][1], arrComp.components[1]);
         assert.strictEqual(arrComp.rows[1][0], arrComp.components[2]);
         assert.strictEqual(arrComp.rows[1][1], arrComp.components[3]);
+        assert.strictEqual(arrComp.rows[2][0], arrComp.components[4]);
+        assert.strictEqual(arrComp.rows[2][1], arrComp.components[5]);
         assert.equal(arrComp.components[2].dataValue, 'Sally');
         assert.equal(arrComp.components[3].dataValue, 'Thompson');
+        assert.equal(arrComp.components[4].dataValue, 'Jane');
+        assert.equal(arrComp.components[5].dataValue, 'Doe');
 
         // Ensure it removes rows.
         employees = [

--- a/src/experimental/model/NestedArrayModel.ts
+++ b/src/experimental/model/NestedArrayModel.ts
@@ -152,7 +152,7 @@ export function NestedArrayModel(props: any = {}) : ModelDecoratorInterface {
 
                     // Remove superfluous rows.
                     if (dataValue.length > value.length) {
-                        for (let i = value.length; i < dataValue.length; i++) {
+                        for (let i = dataValue.length - 1; i >= value.length; i--) {
                             this.removeRow(i);
                         }
                     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8901

## Description

**Issue:** When setting a nested array model's `dataValue` to a smaller size than it was previously, the new `dataValue` contains more items than it should. This happens because when we remove excessive items by iterating over the array from the beginning, each removal causes the subsequent elements to shift left, leading to skipped elements during iteration.

**Solution:** Iterate over the array in reverse order to avoid skipping elements when removing items.

## How has this PR been tested?

Updated the existing test case.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
