### PR TITLE
FIO-9055: separate rowPath from componentPath in getComponentActualValue fn

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -2701,6 +2701,213 @@ describe('Process Tests', () => {
     });
   });
 
+  it('Should allow conditionally hidden components that depend on state outside of the contextual row data', async () => {
+    const form = {
+      display: 'form',
+      components: [
+        {
+          label: 'Select',
+          widget: 'choicesjs',
+          tableView: true,
+          data: {
+            values: [
+              {
+                label: 'Action1',
+                value: 'action1',
+              },
+              {
+                label: 'Custom',
+                value: 'custom',
+              },
+            ],
+          },
+          key: 'select',
+          type: 'select',
+          input: true,
+        },
+        {
+          label: 'Edit Grid',
+          tableView: false,
+          rowDrafts: false,
+          key: 'editGrid',
+          type: 'editgrid',
+          displayAsTable: false,
+          input: true,
+          components: [
+            {
+              label: 'Text Field',
+              applyMaskOn: 'change',
+              tableView: true,
+              key: 'textField',
+              conditional: {
+                show: true,
+                conjunction: 'all',
+                conditions: [
+                  {
+                    component: 'select',
+                    operator: 'isEqual',
+                    value: 'custom',
+                  },
+                ],
+              },
+              type: 'textfield',
+              input: true,
+            },
+          ],
+        },
+        {
+          type: 'button',
+          label: 'Submit',
+          key: 'submit',
+          disableOnInvalid: true,
+          input: true,
+          tableView: false,
+        },
+      ],
+    };
+
+    const submission = {
+      data: {
+        select: 'custom',
+        editGrid: [
+          {
+            textField: 'TEST',
+          },
+        ],
+      },
+    };
+
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.evaluator,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    expect(context.data).to.deep.equal({
+      select: 'custom',
+      editGrid: [
+        {
+          textField: 'TEST',
+        },
+      ],
+    });
+  });
+
+  it('Should allow conditionally hidden components that depend on state outside of the contextual row data with nested structures', async () => {
+    const form = {
+      display: 'form',
+      components: [
+        {
+          key: 'container',
+          type: 'container',
+          components: [
+            {
+              label: 'Select',
+              widget: 'choicesjs',
+              tableView: true,
+              data: {
+                values: [
+                  {
+                    label: 'Action1',
+                    value: 'action1',
+                  },
+                  {
+                    label: 'Custom',
+                    value: 'custom',
+                  },
+                ],
+              },
+              key: 'select',
+              type: 'select',
+              input: true,
+            },
+          ],
+          input: true
+        },
+        {
+          label: 'Edit Grid',
+          tableView: false,
+          rowDrafts: false,
+          key: 'editGrid',
+          type: 'editgrid',
+          displayAsTable: false,
+          input: true,
+          components: [
+            {
+              label: 'Text Field',
+              applyMaskOn: 'change',
+              tableView: true,
+              key: 'textField',
+              conditional: {
+                show: true,
+                conjunction: 'all',
+                conditions: [
+                  {
+                    component: 'container.select',
+                    operator: 'isEqual',
+                    value: 'custom',
+                  },
+                ],
+              },
+              type: 'textfield',
+              input: true,
+            },
+          ],
+        },
+        {
+          type: 'button',
+          label: 'Submit',
+          key: 'submit',
+          disableOnInvalid: true,
+          input: true,
+          tableView: false,
+        },
+      ],
+    };
+
+    const submission = {
+      data: {
+        container: {
+          select: 'custom',
+        },
+        editGrid: [
+          {
+            textField: 'TEST',
+          },
+        ],
+      },
+    };
+
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.evaluator,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    expect(context.data).to.deep.equal({
+      container: {
+        select: 'custom',
+      },
+      editGrid: [
+        {
+          textField: 'TEST',
+        },
+      ],
+    });
+  });
+
   it('Should include submission data for logically visible fields', async () => {
     const form = {
       display: 'form',

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -2908,6 +2908,257 @@ describe('Process Tests', () => {
     });
   });
 
+  it('Should allow conditionally hidden components that depend on state outside of the contextual row data, with co-located component keys in the row that are not targets of conditions', async () => {
+    const form = {
+      display: 'form',
+      components: [
+        {
+          label: 'Select',
+          widget: 'choicesjs',
+          tableView: true,
+          data: {
+            values: [
+              {
+                label: 'Action1',
+                value: 'action1',
+              },
+              {
+                label: 'Custom',
+                value: 'custom',
+              },
+            ],
+          },
+          key: 'select',
+          type: 'select',
+          input: true,
+        },
+        {
+          label: 'Edit Grid',
+          tableView: false,
+          rowDrafts: false,
+          key: 'editGrid',
+          type: 'editgrid',
+          displayAsTable: false,
+          input: true,
+          components: [
+            {
+              label: 'Text Field',
+              applyMaskOn: 'change',
+              tableView: true,
+              key: 'textField',
+              conditional: {
+                show: true,
+                conjunction: 'all',
+                conditions: [
+                  {
+                    component: 'select',
+                    operator: 'isEqual',
+                    value: 'custom',
+                  },
+                ],
+              },
+              type: 'textfield',
+              input: true,
+            },
+            {
+              label: 'Select',
+              widget: 'choicesjs',
+              tableView: true,
+              data: {
+                values: [
+                  {
+                    label: 'Action1',
+                    value: 'action1',
+                  },
+                  {
+                    label: 'Custom',
+                    value: 'custom',
+                  },
+                ],
+              },
+              key: 'select',
+              type: 'select',
+              input: true,
+            },
+          ]
+        },
+        {
+          type: 'button',
+          label: 'Submit',
+          key: 'submit',
+          disableOnInvalid: true,
+          input: true,
+          tableView: false,
+        },
+      ],
+    };
+
+    const submission = {
+      data: {
+        select: 'custom',
+        editGrid: [
+          {
+            textField: 'TEST',
+            select: 'action1'
+          },
+        ],
+      },
+    };
+
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.evaluator,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    expect(context.data).to.deep.equal({
+      select: 'custom',
+      editGrid: [
+        {
+          textField: 'TEST',
+          select: 'action1'
+        },
+      ],
+    });
+  });
+
+  it('Should allow conditionally hidden components that depend on state outside of the contextual row data, with nested and co-located component keys in the row that are not targets of conditions', async () => {
+    const form = {
+      display: 'form',
+      components: [
+        {
+          type: 'container',
+          key: 'container',
+          input: true,
+          components: [
+            {
+              label: 'Select',
+              widget: 'choicesjs',
+              tableView: true,
+              data: {
+                values: [
+                  {
+                    label: 'Action1',
+                    value: 'action1',
+                  },
+                  {
+                    label: 'Custom',
+                    value: 'custom',
+                  },
+                ],
+              },
+              key: 'select',
+              type: 'select',
+              input: true,
+            },
+            {
+              label: 'Edit Grid',
+              tableView: false,
+              rowDrafts: false,
+              key: 'editGrid',
+              type: 'editgrid',
+              displayAsTable: false,
+              input: true,
+              components: [
+                {
+                  label: 'Text Field',
+                  applyMaskOn: 'change',
+                  tableView: true,
+                  key: 'textField',
+                  conditional: {
+                    show: true,
+                    conjunction: 'all',
+                    conditions: [
+                      {
+                        component: 'container.select',
+                        operator: 'isEqual',
+                        value: 'custom',
+                      },
+                    ],
+                  },
+                  type: 'textfield',
+                  input: true,
+                },
+                {
+                  label: 'Select',
+                  widget: 'choicesjs',
+                  tableView: true,
+                  data: {
+                    values: [
+                      {
+                        label: 'Action1',
+                        value: 'action1',
+                      },
+                      {
+                        label: 'Custom',
+                        value: 'custom',
+                      },
+                    ],
+                  },
+                  key: 'select',
+                  type: 'select',
+                  input: true,
+                },
+              ]
+            },
+          ],
+        },
+        {
+          type: 'button',
+          label: 'Submit',
+          key: 'submit',
+          disableOnInvalid: true,
+          input: true,
+          tableView: false,
+        },
+      ],
+    };
+
+    const submission = {
+      data: {
+        container: {
+          select: 'custom',
+          editGrid: [
+            {
+              textField: 'TEST',
+              select: 'action1'
+            },
+          ],
+        }
+      },
+    };
+
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.evaluator,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    expect(context.data).to.deep.equal({
+      container: {
+        select: 'custom',
+        editGrid: [
+          {
+            textField: 'TEST',
+            select: 'action1'
+          },
+        ],
+      }
+    });
+  });
+
   it('Should include submission data for logically visible fields', async () => {
     const form = {
       display: 'form',

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -652,6 +652,7 @@ export function getComponentActualValue(component: Component, compPath: string, 
   //
   let parentInputComponent: any = null;
   let parent = component;
+  let rowPath = '';
 
   while (parent?.parent?.path && !parentInputComponent) {
     parent = parent.parent;
@@ -662,13 +663,13 @@ export function getComponentActualValue(component: Component, compPath: string, 
 
   if (parentInputComponent) {
     const parentCompPath = parentInputComponent.path.replace(/\[[0-9]+\]/g, '');
-    compPath = compPath.replace(parentCompPath, '');
-    compPath = trim(compPath, '. ');
+    rowPath = compPath.replace(parentCompPath, '');
+    rowPath = trim(rowPath, '. ');
   }
 
   let value = null;
-  if (row) {
-    value = get(row, compPath);
+  if (rowPath && row) {
+    value = get(row, rowPath);
   }
   if (data && isNil(value)) {
     value = get(data, compPath);

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -668,11 +668,11 @@ export function getComponentActualValue(component: Component, compPath: string, 
   }
 
   let value = null;
-  if (rowPath && row) {
-    value = get(row, rowPath);
-  }
-  if (data && isNil(value)) {
+  if (data) {
     value = get(data, compPath);
+  }
+  if (rowPath && row && isNil(value)) {
+    value = get(row, rowPath);
   }
   if (isNil(value) || (isObject(value) && isEmpty(value))) {
     value = '';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9055

## Description

Previously, nested data components (e.g. edit grid, container, data grid, etc.) did not handle the case of a conditional component that was _outside_ of the component's contextual row value. In other words, an edit grid component that contains a child text field that itself contains a conditional based on a parent-level component:

```
    const form = {
      display: 'form',
      components: [
        {
          label: 'Select',
          widget: 'choicesjs',
          tableView: true,
          data: {
            values: [
              {
                label: 'Action1',
                value: 'action1',
              },
              {
                label: 'Custom',
                value: 'custom',
              },
            ],
          },
          key: 'select',
          type: 'select',
          input: true,
        },
        {
          label: 'Edit Grid',
          tableView: false,
          rowDrafts: false,
          key: 'editGrid',
          type: 'editgrid',
          displayAsTable: false,
          input: true,
          components: [
            {
              label: 'Text Field',
              applyMaskOn: 'change',
              tableView: true,
              key: 'textField',
              conditional: {
                show: true,
                conjunction: 'all',
                conditions: [
                  {
                    component: 'select',
                    operator: 'isEqual',
                    value: 'custom',
                  },
                ],
              },
              type: 'textfield',
              input: true,
            },
          ],
        },
        {
          type: 'button',
          label: 'Submit',
          key: 'submit',
          disableOnInvalid: true,
          input: true,
          tableView: false,
        },
      ],
    };
```

could not reach outside of its contextual row context to get the correct value. This PR updates the `getComponentActualValue` method so that `rowPath` and a full `componentPath` are separate.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Manually + automated testing; formio and formio-server tests pass

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
