### PR TITLE
FIO-9059: fixed an issue where  the string type returns for textarea with json type

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -3408,6 +3408,79 @@ describe('Process Tests', () => {
     expect(context.submission.data.textField).to.be.equal('some text');
   });
 
+  it('Should not return validation error for multiple textarea with json data type when first value is array', async () => {
+    const form =   {
+      _id: '66f676f14b77db82b230a201',
+      title: 'teterter',
+      name: 'teterter',
+      path: 'teterter',
+      type: 'form',
+      display: 'form',
+      owner: '64b642526f32c9c544728ea8',
+      components: [
+        {
+          label: 'Text Area',
+          applyMaskOn: 'change',
+          editor: 'ace',
+          autoExpand: false,
+          tableView: true,
+          multiple: true,
+          validateWhenHidden: false,
+          key: 'textArea',
+          type: 'textarea',
+          as: 'json',
+          input: true,
+        },
+        {
+          type: 'button',
+          label: 'Submit',
+          key: 'submit',
+          disableOnInvalid: true,
+          input: true,
+          tableView: false,
+        },
+      ],
+      project: '66f27e5fcb2889b75ac52c6e',
+      created: '2024-09-27T09:12:17.478Z',
+      modified: '2024-09-27T09:15:07.820Z',
+      machineName: 'qcuzcnfwbclumuw:teterter',
+    };
+
+    const submission = {
+      form: '66f678ee5879bf08113d361c',
+      owner: '637b2e6b48c1227e60b1f910',
+      data: {
+        textAreaJson: [
+          [1, 2, 3],
+          [4, 5, 6],
+        ],
+        submit: true,
+      },
+      _id: '66f68c17481ea2ffbf5bb310',
+      project: '66f66c655879bf08113cf4ed',
+      state: 'submitted',
+    };
+
+    const errors: any = [];
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.submission,
+      scope: { errors },
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    processSync(context);
+    assert.equal(context.scope.errors.length, 0);
+  });
+
+
   describe('Required component validation in nested form in DataGrid/EditGrid', () => {
     const nestedForm = {
       key: 'form',

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -86,7 +86,8 @@ export const validateMultipleSync: RuleFnSync = (
 
   const shouldBeMultipleArray = !!component.multiple;
   const isRequired = !!component.validate?.required;
-  const underlyingValueShouldBeArray = getModelType(component) === 'nestedArray' || (isTagsComponent(component) && component.storeas === 'array');
+  const compModelType = getModelType(component);
+  const underlyingValueShouldBeArray = compModelType === 'nestedArray' || (isTagsComponent(component) && component.storeas === 'array');
   const valueIsArray = Array.isArray(value);
 
   if (shouldBeMultipleArray) {
@@ -105,7 +106,7 @@ export const validateMultipleSync: RuleFnSync = (
         return isRequired ? new FieldError('array_nonempty', { ...context, setting: true }) : null;
       }
 
-      return Array.isArray(value[0]) ? new FieldError('nonarray', { ...context, setting: true }) : null;
+      return Array.isArray(value[0]) && compModelType !== 'any' ? new FieldError('nonarray', { ...context, setting: true }) : null;
     } else {
       const error = new FieldError('array', { ...context, setting: true });
       // Null/undefined is ok if this value isn't required; anything else should fail

--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -1815,6 +1815,19 @@ describe('hasCondition', () => {
 });
 
 describe('getModelType', () => {
+    it('Should return the correct model type for taxtarea with JSON data type', () => {
+        const component = {
+            type: 'textarea',
+            input: true,
+            key: 'textField',
+            editor: 'ace',
+            as: 'json'
+        };
+        const actual = getModelType(component);
+        const expected = 'any';
+        expect(actual).to.equal(expected);
+    });
+
     it('Should return the correct model type for a component', () => {
         const component = {
             type: 'textfield',

--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -1947,7 +1947,7 @@ describe('getModelType', () => {
             key: 'textarea',
         };
         const actual = getModelType(component);
-        const expected = 'string';
+        const expected = 'any';
         expect(actual).to.equal(expected);
     });
 

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -193,6 +193,12 @@ export function getModelType(component: Component): keyof typeof MODEL_TYPES_OF_
     return component.modelType;
   }
 
+  switch (component.type) {
+    case 'textarea':
+      if (['json'].includes((component as any).as)) {
+        return 'any';
+      };
+  }
   // Otherwise, check for known component types.
   for (const type of Object.keys(MODEL_TYPES_OF_KNOWN_COMPONENTS) as (keyof typeof MODEL_TYPES_OF_KNOWN_COMPONENTS)[]) {
     if (MODEL_TYPES_OF_KNOWN_COMPONENTS[type].includes(component.type)) {

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -146,7 +146,6 @@ export const MODEL_TYPES_OF_KNOWN_COMPONENTS = {
   ],
   string: [
     'textfield',
-    'textarea',
     'password',
     'email',
     'url',
@@ -175,6 +174,7 @@ export const MODEL_TYPES_OF_KNOWN_COMPONENTS = {
   any: [
     'survey',
     'captcha',
+    'textarea',
     'selectboxes',
     'tags',
     'select',
@@ -193,12 +193,6 @@ export function getModelType(component: Component): keyof typeof MODEL_TYPES_OF_
     return component.modelType;
   }
 
-  switch (component.type) {
-    case 'textarea':
-      if (['json'].includes((component as any).as)) {
-        return 'any';
-      };
-  }
   // Otherwise, check for known component types.
   for (const type of Object.keys(MODEL_TYPES_OF_KNOWN_COMPONENTS) as (keyof typeof MODEL_TYPES_OF_KNOWN_COMPONENTS)[]) {
     if (MODEL_TYPES_OF_KNOWN_COMPONENTS[type].includes(component.type)) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9059

## Description

**What changed?**

Added a check that returns any type for textarea that is configured to save as JSON

## Dependencies

https://github.com/formio/formio.js/pull/5829

## How has this PR been tested?

tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
