### PR TITLE
FIO-9033 tagpad data is not saved

### DIFF
--- a/src/process/filter/__tests__/filter.test.ts
+++ b/src/process/filter/__tests__/filter.test.ts
@@ -79,6 +79,83 @@ it("Should not filter empty array value for dataTable component", async () => {
   });
 });
 
+it("Should not filter coordinates for Tagpad component", async () => {
+  const tagpadComp = {
+    label: 'Tagpad',
+    imageUrl: 'https://onetreeplanted.org/cdn/shop/articles/nature_facts_1600x.jpg?v=1705008496',
+    tableView: false,
+    validateWhenHidden: false,
+    key: 'tagpad',
+    type: 'tagpad',
+    input: true,
+    components: [
+      {
+        label: 'Text Field',
+        applyMaskOn: 'change',
+        tableView: true,
+        validateWhenHidden: false,
+        key: 'textField',
+        type: 'textfield',
+        input: true,
+      },
+    ],
+  };
+  const data = {
+    tagpad: [
+      {
+        coordinate: {
+          x: 83,
+          y: 61,
+          width: 280,
+          height: 133,
+        },
+        data: {
+          textField: 'test1',
+        },
+      },
+      {
+        coordinate: {
+          x: 194,
+          y: 93,
+          width: 280,
+          height: 133,
+        },
+        data: {
+          textField: 'test2',
+        },
+      },
+    ],
+  };
+  const context: any = generateProcessorContext(tagpadComp, data);
+  filterProcessSync(context);
+  expect(context.scope.filter).to.deep.equal({
+    tagpad: {
+      compModelType: 'nestedDataArray',
+      include: true,
+      value: [
+        {
+          coordinate: {
+            x: 83,
+            y: 61,
+            width: 280,
+            height: 133,
+          },
+          data: {},
+        },
+        {
+          coordinate: {
+            x: 194,
+            y: 93,
+            width: 280,
+            height: 133,
+          },
+          data: {},
+        },
+      ],
+    },
+  });
+});
+
 it("Should not filter the datamap component", async () => {
   const dataMapComp = {
     label: "Data Map",

--- a/src/process/filter/__tests__/filter.test.ts
+++ b/src/process/filter/__tests__/filter.test.ts
@@ -86,6 +86,7 @@ it("Should not filter coordinates for Tagpad component", async () => {
     tableView: false,
     validateWhenHidden: false,
     key: 'tagpad',
+    path: 'tagpad',
     type: 'tagpad',
     input: true,
     components: [

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -25,6 +25,13 @@ export const filterProcessSync: ProcessorFnSync<FilterScope> = (context: FilterC
           value: []
         };
         break;
+      case 'nestedDataArray':
+        scope.filter[absolutePath] = {
+          compModelType: modelType,
+          include: true,
+          value: Array.isArray(value) ? value.map(v => ({...v, data: {}})) : [],
+        };
+        break;
       case 'object':
         scope.filter[absolutePath] = {
           compModelType: modelType,

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -86,7 +86,7 @@ export const validateMultipleSync: RuleFnSync = (
 
   const shouldBeMultipleArray = !!component.multiple;
   const isRequired = !!component.validate?.required;
-  const underlyingValueShouldBeArray = getModelType(component) === 'nestedArray' || (isTagsComponent(component) && component.storeas === 'array');
+  const underlyingValueShouldBeArray = ['nestedArray', 'nestedDataArray'].indexOf(getModelType(component)) !== -1 || (isTagsComponent(component) && component.storeas === 'array');
   const valueIsArray = Array.isArray(value);
 
   if (shouldBeMultipleArray) {

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -109,6 +109,7 @@ export function uniqueName(name: string, template?: string, evalContext?: any) {
  * For now, these will be the only model types supported by the @formio/core library.
  *
  * nestedArray: for components that store their data as an array and have nested components.
+ * nestedDataArray: for components that store their data as an array and have nested components, but keeps the value of nested components inside 'data' property.
  * array: for components that store their data as an array.
  * dataObject: for components that store their data in a nested { data: {} } object.
  * object: for components that store their data in an object.

--- a/src/utils/formUtil.ts
+++ b/src/utils/formUtil.ts
@@ -127,6 +127,8 @@ export const MODEL_TYPES_OF_KNOWN_COMPONENTS = {
     'editgrid',
     'datatable',
     'dynamicWizard',
+  ],
+  nestedDataArray: [
     'tagpad',
   ],
   dataObject: [
@@ -237,6 +239,7 @@ export function getComponentPath(component: Component, path: string) {
 
 export function isComponentNestedDataType(component: any) {
   return component.tree || getModelType(component) === 'nestedArray' ||
+    getModelType(component) === 'nestedDataArray' ||
     getModelType(component) === 'dataObject' ||
     getModelType(component) === 'object' ||
     getModelType(component) === 'map';
@@ -262,6 +265,9 @@ export const componentDataPath = (component: any, parentPath: string, path: stri
     }
     if (getModelType(component) === 'nestedArray') {
       return `${path}[0]`;
+    }
+    if (getModelType(component) === 'nestedDataArray') {
+      return `${path}[0].data`;
     }
     if (isComponentNestedDataType(component)) {
       return path;
@@ -307,11 +313,12 @@ export const eachComponentDataAsync = async (
         const value = get(data, compPath, data);
         if (Array.isArray(value)) {
           for (let i = 0; i < value.length; i++) {
+            const nestedComponentPath = getModelType(component) === 'nestedDataArray' ? `${compPath}[${i}].data` : `${compPath}[${i}]`;
             await eachComponentDataAsync(
               component.components,
               data,
               fn,
-              `${compPath}[${i}]`,
+              nestedComponentPath,
               i,
               component,
               includeAll
@@ -371,7 +378,8 @@ export const eachComponentData = (
         const value = get(data, compPath, data) as DataObject;
         if (Array.isArray(value)) {
           for (let i = 0; i < value.length; i++) {
-            eachComponentData(component.components, data, fn, `${compPath}[${i}]`, i, component, includeAll);
+          const nestedComponentPath = getModelType(component) === 'nestedDataArray' ? `${compPath}[${i}].data` : `${compPath}[${i}]`;
+            eachComponentData(component.components, data, fn, nestedComponentPath, i, component, includeAll);
           }
           return true;
         } else if (isEmpty(row) && !includeAll) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9033

## Description

Previously, Tagpad was assigned to the 'nestedArray' data model that implies that each object inside component's value array will consist of nested components keys. Which is not correct in Tagpad's case, because its value structure is 
[
  {
    coordinates: { x, y },
    data: {},
  },
]
where 'data' is an actual property containing all the nested components' values. 

Because of that during the filter process, Tagpad's value was assigned to an empty array and was never refilled with nested component's values. 
New data type called 'nestedDataArray' was provided for such scenarios where it looks for the nested component's values inside 'data' property of each object in the array and does not clear any property outside of the 'data' one 

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
