### PR TITLE
FIO-9086: use for validation only dataFormat

### DIFF
--- a/src/process/validation/rules/__tests__/validateTime.test.ts
+++ b/src/process/validation/rules/__tests__/validateTime.test.ts
@@ -10,7 +10,8 @@ const timeField: TimeComponent = {
     key: 'time',
     label: 'Time',
     input: true,
-    dataFormat: 'HH:mm:ss'
+    dataFormat: 'HH:mm:ss',
+    format: 'HH:mm'
 };
 
 it('Should validate a time component with a valid time value', async () => {

--- a/src/process/validation/rules/validateTime.ts
+++ b/src/process/validation/rules/validateTime.ts
@@ -28,10 +28,7 @@ export const validateTimeSync: RuleFnSync = (context: ValidationContext) => {
     }
     try {
         if (!value || isComponentDataEmpty(component, data, path)) return null;
-        // Server side evaluations of validity should use the "dataFormat" vs the "format" which is used on the client.
-        const format = config?.server ?
-            ((component as TimeComponent).dataFormat || 'HH:mm:ss') :
-            ((component as TimeComponent).format || 'HH:mm');
+        const format = (component as TimeComponent).dataFormat || 'HH:mm:ss';
         const isValid = dayjs(String(value), format, true).isValid();
         return isValid ? null : new FieldError('time', context);
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9086

## Description
Time component validation was changed as follows:
Server side and client side evaluations of validity use component dataFormat for validation.

For correct use on client side wad added changes on formio.js ( only this.dataValue is used for validation)


## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?
manually 

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
