### PR TITLE
FIO-9086: use for validation only dataFormat (data storage format)

### DIFF
--- a/src/process/validation/__tests__/Validator.test.ts
+++ b/src/process/validation/__tests__/Validator.test.ts
@@ -15,6 +15,7 @@ it('Validator will throw the correct errors given a flat components array', asyn
         email: 'brendanb',
         url: 'htpigoogle',
         inputMask: 'hello, world',
+        time: ['12:00:00', '11:00'], // one of the values is provided in incorrect format (format instead dataFormat)
         submit: false,
     };
     for (let component of simpleForm.components) {
@@ -34,5 +35,5 @@ it('Validator will throw the correct errors given a flat components array', asyn
             errors = [...errors, ...scope.errors.map((error) => error.errorKeyOrMessage)];
         }
     }
-    expect(errors).to.have.length(6);
+    expect(errors).to.have.length(7);
 });

--- a/src/process/validation/__tests__/fixtures/forms.ts
+++ b/src/process/validation/__tests__/fixtures/forms.ts
@@ -2290,6 +2290,15 @@ export const simpleForm = {
             id: 'e8vls3a',
             keyModified: true,
         },
+        {   
+            label: 'Time',
+            type: 'time',
+            key: 'time',
+            input: true,
+            dataFormat: 'HH:mm:ss',
+            format: 'HH:mm',
+            multiple: true,
+        },
         {
             type: 'button',
             label: 'Submit',
@@ -2297,7 +2306,7 @@ export const simpleForm = {
             disableOnInvalid: true,
             input: true,
             tableView: false,
-        },
+        }
     ],
     settings: {},
     properties: {},

--- a/src/process/validation/rules/__tests__/validateTime.test.ts
+++ b/src/process/validation/rules/__tests__/validateTime.test.ts
@@ -10,7 +10,8 @@ const timeField: TimeComponent = {
     key: 'time',
     label: 'Time',
     input: true,
-    dataFormat: 'HH:mm:ss'
+    dataFormat: 'HH:mm:ss',
+    format: 'HH:mm'
 };
 
 it('Should validate a time component with a valid time value', async () => {

--- a/src/process/validation/rules/validateTime.ts
+++ b/src/process/validation/rules/validateTime.ts
@@ -28,10 +28,7 @@ export const validateTimeSync: RuleFnSync = (context: ValidationContext) => {
     }
     try {
         if (!value || isComponentDataEmpty(component, data, path)) return null;
-        // Server side evaluations of validity should use the "dataFormat" vs the "format" which is used on the client.
-        const format = config?.server ?
-            ((component as TimeComponent).dataFormat || 'HH:mm:ss') :
-            ((component as TimeComponent).format || 'HH:mm');
+        const format = (component as TimeComponent).dataFormat || 'HH:mm:ss';
         const isValid = dayjs(String(value), format, true).isValid();
         return isValid ? null : new FieldError('time', context);
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9086

## Description

Time component validation was changed as follows:
Server side and client side evaluations of validity use component dataFormat for validation.
For correct use on client side wad added changes on formio.js ( only this.dataValue is used for validation)
Those changes help avoid validation errors caused by mismatches between data display and storage format.

## Dependencies

https://github.com/formio/formio.js/pull/5834

manually,
autotests

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
