### PR TITLE
FIO-9280 updated validation of value property

### DIFF
--- a/src/process/validation/rules/__tests__/validateValueProperty.test.ts
+++ b/src/process/validation/rules/__tests__/validateValueProperty.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import { set } from 'lodash';
+import { FieldError } from 'error';
+import { SelectBoxesComponent } from 'types';
+import {
+  simpleRadioField,
+  simpleSelectBoxes
+} from './fixtures/components';
+import { generateProcessorContext } from './fixtures/util';
+import { validateValueProperty } from '../validateValueProperty';
+
+describe('validateValueProperty', function () {
+  it('Validating a component with support for different types will return null', async function () {
+    const component = simpleRadioField;
+    const data = {
+      component: 'test',
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateValueProperty(context);
+    expect(result).to.equal(null);
+  });
+
+  it('Validating a select boxes component with values data source will return null', async function () {
+    const component = simpleSelectBoxes;
+    const data = {
+      component: {
+        foo: false,
+        bar: false,
+        baz: false,
+        biz: false,
+      },
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateValueProperty(context);
+    expect(result).to.equal(null);
+  });
+
+  it('Validating a select boxes component with url data source without options building will return null', async function () {
+    const component: SelectBoxesComponent = {
+      ...simpleSelectBoxes,
+      dataSrc: 'url',
+      values: [],
+      data: {
+        url: 'http://localhost:8080/numbers',
+        headers: [],
+      },
+    };
+    const data = {component: { 'true': true }};
+
+    const context = generateProcessorContext(component, data);
+    const result = await validateValueProperty(context);
+    expect(result).to.equal(null);
+  });
+
+  it('Validating a select boxes component with url data source without options building will return error', async function () {
+    const component: SelectBoxesComponent = {
+      ...simpleSelectBoxes,
+      dataSrc: 'url',
+      values: [],
+      data: {
+        url: 'http://localhost:8080/numbers',
+        headers: [],
+      },
+    };
+    const data =  {component: { 'true': true }};
+
+    const context = generateProcessorContext(component, data);
+    set(context, 'instance.options.building', true);
+    const result = await validateValueProperty(context);
+    expect(result).to.be.instanceOf(FieldError);
+    expect(result?.errorKeyOrMessage).to.equal('invalidValueProperty');
+  });
+});

--- a/src/types/PassedComponentInstance.ts
+++ b/src/types/PassedComponentInstance.ts
@@ -19,4 +19,5 @@ export type PassedComponentInstance = {
   evaluate: (expression: string, additionalContext?: Record<string, any>) => any;
   interpolate: (text: string, additionalContext?: Record<string, any>) => string;
   shouldSkipValidation: (data?: DataObject, row?: DataObject) => boolean;
+  loadedOptions?: Array<{invalid: boolean, value: any, label: string}>
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9280

## Description

*Since the Radio component and the Select component support various data types, including objects and boolean values, validation of the value property is triggered only for the Select Boxes component. Also, validation is triggered only in the form builder. If the value for the SelectBoxes component is invalid, an error is displayed that does not allow saving the component with invalid values.*

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

*https://github.com/formio/formio.js/pull/5894*

## How has this PR been tested?

locally, automated tests have been added

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
