### PR TITLE
FIO-9266,FIO-9267,FIO-9268: Fixes an issue where nested forms will be not validated if there are no data provided

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -4548,6 +4548,135 @@ describe('Process Tests', function () {
     });
   });
 
+  it("Should validate Nested Form's components if it should not be cleared and no data provided", async function () {
+    const nestedForm = {
+      key: 'form',
+      type: 'form',
+      display: 'form',
+      input: true,
+      components: [
+        {
+          key: 'textField',
+          type: 'textfield',
+          validate: {
+            required: true,
+          },
+          input: true,
+        },
+      ],
+    };
+    const submission = {
+      data: {
+        submit: true,
+      },
+      state: 'submitted',
+    };
+    const form = {
+      title: 'Parent Form',
+      name: 'parentForm',
+      path: 'parentform',
+      type: 'form',
+      display: 'form',
+      components: [
+        nestedForm,
+        {
+          ...nestedForm,
+          key: 'form1',
+        },
+        {
+          type: 'button',
+          label: 'Submit',
+          key: 'submit',
+          input: true,
+          tableView: false,
+        },
+      ],
+    };
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.submission,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    context.processors = ProcessTargets.evaluator;
+    const scope = processSync(context);
+    expect((scope as ValidationScope).errors).to.have.length(2);
+  });
+
+  it("Should validate Nested Form's components if it should not be cleared and no data provided and the parent form has errors itself", async function () {
+    const nestedForm = {
+      key: 'form',
+      type: 'form',
+      input: true,
+      components: [
+        {
+          key: 'textField',
+          type: 'textfield',
+          validate: {
+            required: true,
+          },
+          input: true,
+        },
+      ],
+    };
+    const submission = {
+      data: {
+        submit: true,
+      },
+      state: 'submitted',
+    };
+    const form = {
+      title: 'Parent Form',
+      name: 'parentForm',
+      path: 'parentform',
+      type: 'form',
+      display: 'form',
+      components: [
+        {
+          key: 'textField',
+          type: 'textfield',
+          validate: {
+            required: true,
+          },
+          input: true,
+        },
+        nestedForm,
+        {
+          ...nestedForm,
+          key: 'form1',
+        },
+        {
+          type: 'button',
+          label: 'Submit',
+          key: 'submit',
+          input: true,
+          tableView: false,
+        },
+      ],
+    };
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.submission,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    context.processors = ProcessTargets.evaluator;
+    const scope = processSync(context);
+    expect((scope as ValidationScope).errors).to.have.length(3);
+  });
+
   it('Should not return errors for empty multiple values for url and dateTime', function () {
     const form = {
       _id: '671f7fbeaf87b0e2a26e4212',

--- a/src/utils/formUtil/eachComponentData.ts
+++ b/src/utils/formUtil/eachComponentData.ts
@@ -27,7 +27,7 @@ export const eachComponentData = (
   parent?: Component,
   includeAll: boolean = false,
 ) => {
-  if (!components || !data) {
+  if (!components) {
     return;
   }
   return eachComponent(
@@ -61,14 +61,16 @@ export const eachComponentData = (
           return true;
         }
         if (getModelType(component) === 'dataObject') {
-          // No need to bother processing all the children data if there is no data for this form or the reference value has not been loaded.
           const nestedFormValue: any = get(data, component.path);
-          const noReferenceAttached =
-            nestedFormValue?._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
-          const shouldProcessNestedFormData = nestedFormValue?._id
-            ? !noReferenceAttached
-            : has(data, component.path);
-          if (shouldProcessNestedFormData) {
+          const noReferenceAttached = nestedFormValue?._id
+            ? isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form')
+            : false;
+          const shouldBeCleared =
+            (!component.hasOwnProperty('clearOnHide') || component.clearOnHide) &&
+            (component.hidden || component.ephemeralState?.conditionallyHidden);
+          // Skip all the nested components processing if nested form is hidden and should be cleared on hide or if submission is saved as reference and not loaded
+          const shouldSkipProcessingNestedFormData = noReferenceAttached || shouldBeCleared;
+          if (!shouldSkipProcessingNestedFormData) {
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
             const childPath: string = componentDataPath(component, path, compPath);
             const childData: any = get(data, childPath, {});

--- a/src/utils/formUtil/eachComponentDataAsync.ts
+++ b/src/utils/formUtil/eachComponentDataAsync.ts
@@ -1,4 +1,4 @@
-import { get, set, has, isEmpty } from 'lodash';
+import { get, set, isEmpty, has } from 'lodash';
 
 import {
   Component,
@@ -28,7 +28,7 @@ export const eachComponentDataAsync = async (
   parent?: Component,
   includeAll: boolean = false,
 ) => {
-  if (!components || !data) {
+  if (!components) {
     return;
   }
   return await eachComponentAsync(
@@ -64,14 +64,16 @@ export const eachComponentDataAsync = async (
           return true;
         }
         if (getModelType(component) === 'dataObject') {
-          // No need to bother processing all the children data if there is no data for this form or the reference value has not been loaded.
           const nestedFormValue: any = get(data, component.path);
-          const noReferenceAttached =
-            nestedFormValue?._id && isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form');
-          const shouldProcessNestedFormData = nestedFormValue?._id
-            ? !noReferenceAttached
-            : has(data, component.path);
-          if (shouldProcessNestedFormData) {
+          const noReferenceAttached = nestedFormValue?._id
+            ? isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form')
+            : false;
+          const shouldBeCleared =
+            (!component.hasOwnProperty('clearOnHide') || component.clearOnHide) &&
+            (component.hidden || component.ephemeralState?.conditionallyHidden);
+          // Skip all the nested components processing if nested form is hidden and should be cleared on hide or if submission is saved as reference and not loaded
+          const shouldSkipProcessingNestedFormData = noReferenceAttached || shouldBeCleared;
+          if (!shouldSkipProcessingNestedFormData) {
             // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
             const childPath: string = componentDataPath(component, path, compPath);
             const childData: any = get(data, childPath, null);


### PR DESCRIPTION

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9266
https://formio.atlassian.net/browse/FIO-9267
https://formio.atlassian.net/browse/FIO-9268

## Description

Previously, we were skipping processing any Nested Form's child components if there were no data provided for it (if the empty object was provided, it woould not skip though). That was causing an issue with submissions made through API that do not indlude data for the neste form, but must be still validated (because some fields of the child form are required, for example).
After discussion on the dev support we decide that the aussumptions that we can skip processing of nested form's child components if it has no data was wrong and we have to change it.

There are still some cases when we want to skip it: when the nested form's submission is saved as reference and its data is not attached (that means that the child form's data was already validated and saved to DB) or when the nested form itself should be hidden and cleared on hide. 

## Breaking Changes / Backwards Compatibility

_Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility_

## Dependencies

_Use this section to list any dependent changes/PRs in other Form.io modules_

## How has this PR been tested?

_Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning_

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
