### PR TITLE
Refactor the component paths to ensure we are always referencing the correct path.

### DIFF
--- a/src/error/FieldError.ts
+++ b/src/error/FieldError.ts
@@ -1,5 +1,5 @@
-import { getComponentErrorField } from 'process/validation/util';
 import { ValidationContext } from 'types';
+import { getComponentErrorField } from 'utils/formUtil';
 
 type FieldErrorContext = ValidationContext & {
   field?: string;

--- a/src/modules/jsonlogic/index.ts
+++ b/src/modules/jsonlogic/index.ts
@@ -1,5 +1,6 @@
-import { BaseEvaluator, EvaluatorOptions } from 'utils';
+import { normalizeContext } from 'utils/formUtil';
 import { jsonLogic } from './jsonLogic';
+import { BaseEvaluator, EvaluatorOptions, EvaluatorContext } from 'utils/Evaluator';
 export class JSONLogicEvaluator extends BaseEvaluator {
   public static evaluate(
     func: any,
@@ -24,12 +25,6 @@ export class JSONLogicEvaluator extends BaseEvaluator {
   }
 }
 
-export type EvaluatorContext = {
-  evalContext?: (context: any) => any;
-  instance?: any;
-  [key: string]: any;
-};
-
 export type EvaluatorFn = (context: EvaluatorContext) => any;
 
 export function evaluate(
@@ -40,7 +35,9 @@ export function evaluate(
   options: EvaluatorOptions = {},
 ) {
   const { evalContext, instance } = context;
-  const evalContextValue = evalContext ? evalContext(context) : context;
+  const evalContextValue = evalContext
+    ? evalContext(normalizeContext(context))
+    : normalizeContext(context);
   if (evalContextFn) {
     evalContextFn(evalContextValue);
   }
@@ -63,7 +60,9 @@ export function interpolate(
   evalContextFn?: EvaluatorFn,
 ): string {
   const { evalContext, instance } = context;
-  const evalContextValue = evalContext ? evalContext(context) : context;
+  const evalContextValue = evalContext
+    ? evalContext(normalizeContext(context))
+    : normalizeContext(context);
   if (evalContextFn) {
     evalContextFn(evalContextValue);
   }

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -14,7 +14,7 @@ import {
   skipValidForLogicallyHiddenComp,
   skipValidWithHiddenParentComp,
 } from './fixtures';
-import { get } from 'lodash';
+import _ from 'lodash';
 
 /*
 describe('Process Tests', () => {
@@ -959,6 +959,7 @@ describe('Process Tests', function () {
 
     const errors: any = [];
     const context = {
+      _,
       form,
       submission,
       data: submission.data,
@@ -1114,8 +1115,8 @@ describe('Process Tests', function () {
     submission.data = context.data;
     context.processors = ProcessTargets.evaluator;
     processSync(context);
-    assert.equal(get(context.submission.data, 'form1.data.form.data.textField'), 'one 1');
-    assert.equal(get(context.submission.data, 'form1.data.form.data.textField1'), 'two 2');
+    assert.equal(_.get(context.submission.data, 'form1.data.form.data.textField'), 'one 1');
+    assert.equal(_.get(context.submission.data, 'form1.data.form.data.textField1'), 'two 2');
   });
 
   it('should remove submission data not in a nested form definition', async function () {
@@ -3437,7 +3438,7 @@ describe('Process Tests', function () {
     });
   });
 
-  it('Should allow the submission to go through without errors if there is no the subform reference value', async function () {
+  it('Should allow the submission to go through without errors if there is no subform reference value', async function () {
     const form = {
       _id: '66bc5cff7ca1729623a182db',
       title: 'form2',

--- a/src/process/calculation/index.ts
+++ b/src/process/calculation/index.ts
@@ -7,6 +7,7 @@ import {
   ProcessorInfo,
 } from 'types';
 import { set } from 'lodash';
+import { normalizeContext } from 'utils/formUtil';
 
 export const shouldCalculate = (context: CalculationContext): boolean => {
   const { component, config } = context;
@@ -23,7 +24,9 @@ export const calculateProcessSync: ProcessorFnSync<CalculationScope> = (
   if (!shouldCalculate(context)) {
     return;
   }
-  const evalContextValue = evalContext ? evalContext(context) : context;
+  const evalContextValue = evalContext
+    ? evalContext(normalizeContext(context))
+    : normalizeContext(context);
   evalContextValue.value = value || null;
   if (!scope.calculated) scope.calculated = [];
   const newValue = JSONLogicEvaluator.evaluate(component.calculateValue, evalContextValue, 'value');

--- a/src/process/clearHidden.ts
+++ b/src/process/clearHidden.ts
@@ -6,7 +6,6 @@ import {
   ProcessorFnSync,
   ConditionsScope,
 } from 'types';
-import { getComponentAbsolutePath } from 'utils/formUtil';
 
 type ClearHiddenScope = ProcessorScope & {
   clearHidden: {
@@ -19,7 +18,6 @@ type ClearHiddenScope = ProcessorScope & {
  */
 export const clearHiddenProcess: ProcessorFnSync<ClearHiddenScope> = (context) => {
   const { component, data, value, scope, path } = context;
-  const absolutePath = getComponentAbsolutePath(component) || path;
 
   // No need to unset the value if it's undefined
   if (value === undefined) {
@@ -32,7 +30,7 @@ export const clearHiddenProcess: ProcessorFnSync<ClearHiddenScope> = (context) =
 
   // Check if there's a conditional set for the component and if it's marked as conditionally hidden
   const isConditionallyHidden = (scope as ConditionsScope).conditionals?.find((cond) => {
-    return absolutePath === cond.path && cond.conditionallyHidden;
+    return path === cond.path && cond.conditionallyHidden;
   });
 
   const shouldClearValueWhenHidden =
@@ -40,10 +38,10 @@ export const clearHiddenProcess: ProcessorFnSync<ClearHiddenScope> = (context) =
 
   if (
     shouldClearValueWhenHidden &&
-    (isConditionallyHidden || component.hidden || component.ephemeralState?.conditionallyHidden)
+    (isConditionallyHidden || component.hidden || component.scope?.conditionallyHidden)
   ) {
-    unset(data, absolutePath);
-    scope.clearHidden[absolutePath] = true;
+    unset(data, path);
+    scope.clearHidden[path] = true;
   }
 };
 

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -5,7 +5,7 @@ import {
   ProcessorInfo,
   ConditionsContext,
 } from 'types';
-import { registerEphemeralState } from 'utils';
+import { setComponentScope } from 'utils/formUtil';
 import {
   checkCustomConditional,
   checkJsonConditional,
@@ -15,7 +15,6 @@ import {
   isSimpleConditional,
   isJSONConditional,
 } from 'utils/conditions';
-import { getComponentAbsolutePath } from 'utils/formUtil';
 
 const hasCustomConditions = (context: ConditionsContext): boolean => {
   const { component } = context;
@@ -85,7 +84,6 @@ export type ConditionallyHidden = (context: ConditionsContext) => boolean;
 
 export const conditionalProcess = (context: ConditionsContext, isHidden: ConditionallyHidden) => {
   const { scope, path, component } = context;
-  const absolutePath = getComponentAbsolutePath(component) || path;
   if (!hasConditions(context)) {
     return;
   }
@@ -93,16 +91,16 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
   if (!scope.conditionals) {
     scope.conditionals = [];
   }
-  let conditionalComp = scope.conditionals.find((cond) => cond.path === absolutePath);
+  let conditionalComp = scope.conditionals.find((cond) => cond.path === path);
   if (!conditionalComp) {
-    conditionalComp = { path: absolutePath, conditionallyHidden: false };
+    conditionalComp = { path, conditionallyHidden: false };
     scope.conditionals.push(conditionalComp);
   }
 
   conditionalComp.conditionallyHidden =
     conditionalComp.conditionallyHidden || isHidden(context) === true;
   if (conditionalComp.conditionallyHidden) {
-    registerEphemeralState(context.component, 'conditionallyHidden', true);
+    setComponentScope(component, 'conditionallyHidden', true);
   }
 };
 

--- a/src/process/defaultValue/index.ts
+++ b/src/process/defaultValue/index.ts
@@ -7,7 +7,7 @@ import {
   DefaultValueContext,
 } from 'types';
 import { set, has } from 'lodash';
-import { getComponentKey } from 'utils/formUtil';
+import { getComponentKey, normalizeContext } from 'utils/formUtil';
 
 export const hasCustomDefaultValue = (context: DefaultValueContext): boolean => {
   const { component } = context;
@@ -48,7 +48,9 @@ export const customDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
   }
   let defaultValue = null;
   if (component.customDefaultValue) {
-    const evalContextValue = evalContext ? evalContext(context) : context;
+    const evalContextValue = evalContext
+      ? evalContext(normalizeContext(context))
+      : normalizeContext(context);
     evalContextValue.value = null;
     defaultValue = JSONLogicEvaluator.evaluate(
       component.customDefaultValue,

--- a/src/process/fetch/index.ts
+++ b/src/process/fetch/index.ts
@@ -9,7 +9,7 @@ import {
 } from 'types';
 import { get, set } from 'lodash';
 import { Evaluator } from 'utils';
-import { getComponentKey } from 'utils/formUtil';
+import { getComponentKey, normalizeContext } from 'utils/formUtil';
 
 export const shouldFetch = (context: FetchContext): boolean => {
   const { component, config } = context;
@@ -38,7 +38,9 @@ export const fetchProcess: ProcessorFn<FetchScope> = async (context: FetchContex
     return;
   }
   if (!scope.fetched) scope.fetched = {};
-  const evalContextValue = evalContext ? evalContext(context) : context;
+  const evalContextValue = evalContext
+    ? evalContext(normalizeContext(context))
+    : normalizeContext(context);
   const url = Evaluator.interpolateString(get(component, 'fetch.url', ''), evalContextValue);
   if (!url) {
     return;

--- a/src/process/filter/__tests__/filter.test.ts
+++ b/src/process/filter/__tests__/filter.test.ts
@@ -35,7 +35,6 @@ describe('Filter processor', function () {
       type: 'editgrid',
       key: 'editGrid',
       input: true,
-      path: 'editGrid',
       components: [
         {
           type: 'textfield',

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -1,46 +1,44 @@
 import { FilterContext, FilterScope, ProcessorFn, ProcessorFnSync, ProcessorInfo } from 'types';
 import { set } from 'lodash';
-import { Utils } from 'utils';
 import { get, isObject } from 'lodash';
-import { getComponentAbsolutePath } from 'utils/formUtil';
+import { getModelType } from 'utils/formUtil';
 export const filterProcessSync: ProcessorFnSync<FilterScope> = (context: FilterContext) => {
   const { scope, component, path } = context;
   const { value } = context;
-  const absolutePath = getComponentAbsolutePath(component) || path;
   if (!scope.filter) scope.filter = {};
   if (value !== undefined) {
-    const modelType = Utils.getModelType(component);
+    const modelType = getModelType(component);
     switch (modelType) {
       case 'dataObject':
-        scope.filter[absolutePath] = {
+        scope.filter[path] = {
           compModelType: modelType,
           include: true,
           value: { data: {} },
         };
         break;
       case 'nestedArray':
-        scope.filter[absolutePath] = {
+        scope.filter[path] = {
           compModelType: modelType,
           include: true,
           value: [],
         };
         break;
       case 'nestedDataArray':
-        scope.filter[absolutePath] = {
+        scope.filter[path] = {
           compModelType: modelType,
           include: true,
           value: Array.isArray(value) ? value.map((v) => ({ ...v, data: {} })) : [],
         };
         break;
       case 'object':
-        scope.filter[absolutePath] = {
+        scope.filter[path] = {
           compModelType: modelType,
           include: true,
           value: component.type === 'address' ? false : {},
         };
         break;
       default:
-        scope.filter[absolutePath] = {
+        scope.filter[path] = {
           compModelType: modelType,
           include: true,
         };

--- a/src/process/hideChildren.ts
+++ b/src/process/hideChildren.ts
@@ -6,26 +6,24 @@ import {
   ConditionsScope,
   ProcessorFn,
 } from 'types';
-import { registerEphemeralState } from 'utils';
-import { getComponentAbsolutePath } from 'utils/formUtil';
+import { setComponentScope } from 'utils/formUtil';
 
 /**
  * This processor function checks components for the `hidden` property and, if children are present, sets them to hidden as well.
  */
 export const hideChildrenProcessor: ProcessorFnSync<ConditionsScope> = (context) => {
   const { component, path, parent, scope } = context;
-  const absolutePath = getComponentAbsolutePath(component) || path;
   // Check if there's a conditional set for the component and if it's marked as conditionally hidden
   const isConditionallyHidden = scope.conditionals?.find((cond) => {
-    return absolutePath === cond.path && cond.conditionallyHidden;
+    return path === cond.path && cond.conditionallyHidden;
   });
 
   if (!scope.conditionals) {
     scope.conditionals = [];
   }
 
-  if (isConditionallyHidden || component.hidden || parent?.ephemeralState?.conditionallyHidden) {
-    registerEphemeralState(component, 'conditionallyHidden', true);
+  if (isConditionallyHidden || component.hidden || parent?.scope?.conditionallyHidden) {
+    setComponentScope(component, 'conditionallyHidden', true);
   }
 };
 

--- a/src/process/populate/index.ts
+++ b/src/process/populate/index.ts
@@ -1,33 +1,31 @@
-import { get, set } from 'lodash';
+import { set } from 'lodash';
 import { PopulateContext, PopulateScope, ProcessorFnSync } from 'types';
-import { componentPath, getContextualRowPath, getModelType } from 'utils/formUtil';
+import { getModelType } from 'utils/formUtil';
 
 // This processor ensures that a "linked" row context is provided to every component.
 export const populateProcessSync: ProcessorFnSync<PopulateScope> = (context: PopulateContext) => {
-  const { component, path, scope } = context;
+  const { component, path, scope, value } = context;
   const { data } = scope;
-  const compDataPath = componentPath(component, getContextualRowPath(component, path));
-  const compData: any = get(data, compDataPath);
   if (!scope.populated) scope.populated = [];
   switch (getModelType(component)) {
     case 'nestedArray':
-      if (!compData || !compData.length) {
-        set(data, compDataPath, [{}]);
-        scope.row = get(data, compDataPath)[0];
+      if (!value || !value.length) {
+        const newValue = [{}];
+        set(data, path, newValue);
+        scope.row = newValue[0];
         scope.populated.push({
           path,
-          row: get(data, compDataPath)[0],
         });
       }
       break;
     case 'dataObject':
     case 'object':
-      if (!compData || typeof compData !== 'object') {
-        set(data, compDataPath, {});
-        scope.row = get(data, compDataPath);
+      if (!value || typeof value !== 'object') {
+        const newValue = {};
+        set(data, value, newValue);
+        scope.row = newValue;
         scope.populated.push({
           path,
-          row: get(data, compDataPath),
         });
       }
       break;

--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -28,22 +28,19 @@ import { hideChildrenProcessorInfo } from './hideChildren';
 export async function process<ProcessScope>(
   context: ProcessContext<ProcessScope>,
 ): Promise<ProcessScope> {
-  const { instances, components, data, scope, flat, processors } = context;
-
+  const { instances, components, data, scope, flat, processors, local, parent, parentPaths } =
+    context;
   await eachComponentDataAsync(
     components,
     data,
-    async (component, compData, row, path, components, index, parent) => {
-      // Skip processing if row is null or undefined
-      if (!row) {
-        return;
-      }
+    async (component, compData, row, path, components, index, parent, paths) => {
       await processOne<ProcessScope>({
         ...context,
         data: compData,
         component,
         components,
         path,
+        paths,
         row,
         index,
         instance: instances ? instances[path] : undefined,
@@ -57,6 +54,10 @@ export async function process<ProcessScope>(
         return true;
       }
     },
+    false,
+    local,
+    parent,
+    parentPaths,
   );
   for (let i = 0; i < processors?.length; i++) {
     const processor = processors[i];
@@ -68,22 +69,19 @@ export async function process<ProcessScope>(
 }
 
 export function processSync<ProcessScope>(context: ProcessContext<ProcessScope>): ProcessScope {
-  const { instances, components, data, scope, flat, processors } = context;
-
+  const { instances, components, data, scope, flat, processors, local, parent, parentPaths } =
+    context;
   eachComponentData(
     components,
     data,
-    (component, compData, row, path, components, index, parent) => {
-      // Skip processing if row is null or undefined
-      if (!row) {
-        return;
-      }
+    (component, compData, row, path, components, index, parent, paths) => {
       processOneSync<ProcessScope>({
         ...context,
         data: compData,
         component,
         components,
         path,
+        paths,
         row,
         index,
         instance: instances ? instances[path] : undefined,
@@ -97,6 +95,10 @@ export function processSync<ProcessScope>(context: ProcessContext<ProcessScope>)
         return true;
       }
     },
+    false,
+    local,
+    parent,
+    parentPaths,
   );
   for (let i = 0; i < processors?.length; i++) {
     const processor = processors[i];

--- a/src/process/processOne.ts
+++ b/src/process/processOne.ts
@@ -1,42 +1,32 @@
 import { get, set } from 'lodash';
-import { Component, ProcessorsContext, ProcessorType } from 'types';
-import { getComponentKey } from 'utils/formUtil';
-import { resetEphemeralState } from 'utils';
-
-export function dataValue(component: Component, row: any) {
-  const key = getComponentKey(component);
-  return key ? get(row, key) : undefined;
-}
+import { ProcessorsContext, ProcessorType } from 'types';
+import { getModelType } from 'utils/formUtil';
 
 export async function processOne<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
-  const { processors, component, path } = context;
+  const { processors, component, paths, local, path } = context;
   // Create a getter for `value` that is always derived from the current data object
   if (typeof context.value === 'undefined') {
+    const dataPath = local ? paths?.localDataPath || path : paths?.dataPath || path;
     Object.defineProperty(context, 'value', {
       enumerable: true,
       get() {
-        return get(context.data, context.path);
+        const modelType = getModelType(component);
+        if (!component.type || modelType === 'none' || modelType === 'content') {
+          return undefined;
+        }
+        return get(context.data, dataPath);
       },
       set(newValue: any) {
-        set(context.data, context.path, newValue);
+        const modelType = getModelType(component);
+        if (!component.type || modelType === 'none' || modelType === 'content') {
+          // Do not set the value if the model type is 'none' or 'content'
+          return;
+        }
+        set(context.data, dataPath, newValue);
       },
     });
   }
 
-  // Define the component path
-  Object.defineProperty(component, 'path', {
-    enumerable: false,
-    writable: true,
-    value: path,
-  });
-
-  // If the component has ephemeral state, then we need to reset it in case this is e.g. a data grid,
-  // in which each row needs to be validated independently
-  resetEphemeralState(component);
-
-  if (!context.row) {
-    return;
-  }
   context.processor = ProcessorType.Custom;
   for (const processor of processors) {
     if (processor?.process) {
@@ -46,33 +36,31 @@ export async function processOne<ProcessorScope>(context: ProcessorsContext<Proc
 }
 
 export function processOneSync<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
-  const { processors, component, path } = context;
+  const { processors, component, paths, local, path } = context;
   // Create a getter for `value` that is always derived from the current data object
   if (typeof context.value === 'undefined') {
+    const dataPath = local ? paths?.localDataPath || path : paths?.dataPath || path;
     Object.defineProperty(context, 'value', {
       enumerable: true,
       get() {
-        return get(context.data, context.path);
+        const modelType = getModelType(component);
+        if (!component.type || modelType === 'none' || modelType === 'content') {
+          return undefined;
+        }
+        return get(context.data, dataPath);
       },
       set(newValue: any) {
-        set(context.data, context.path, newValue);
+        const modelType = getModelType(component);
+        if (!component.type || modelType === 'none' || modelType === 'content') {
+          // Do not set the value if the model type is 'none' or 'content'
+          return;
+        }
+        set(context.data, dataPath, newValue);
       },
     });
   }
 
-  // Define the component path
-  Object.defineProperty(component, 'path', {
-    enumerable: false,
-    writable: true,
-    value: path,
-  });
-
-  // If the component has ephemeral state, then we need to reset the ephemeral state in case this is e.g. a data grid, in which each row needs to be validated independently
-  resetEphemeralState(component);
-
-  if (!context.row) {
-    return;
-  }
+  // Process the components.
   context.processor = ProcessorType.Custom;
   for (const processor of processors) {
     if (processor?.processSync) {

--- a/src/process/validation/index.ts
+++ b/src/process/validation/index.ts
@@ -14,7 +14,6 @@ import { evaluationRules, rules, serverRules } from './rules';
 import find from 'lodash/find';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
-import { getComponentAbsolutePath } from 'utils/formUtil';
 import { getErrorMessage } from 'utils/error';
 import { FieldError } from 'error';
 import {
@@ -92,10 +91,7 @@ export function isForcedHidden(
   isConditionallyHidden: ConditionallyHidden,
 ): boolean {
   const { component } = context;
-  if (
-    component.ephemeralState?.conditionallyHidden ||
-    isConditionallyHidden(context as ConditionsContext)
-  ) {
+  if (component.scope?.conditionallyHidden || isConditionallyHidden(context as ConditionsContext)) {
     return true;
   }
   if (component.hasOwnProperty('hidden')) {
@@ -160,23 +156,22 @@ export function shouldValidateServer(context: ValidationContext): boolean {
 }
 
 function handleError(error: FieldError | null, context: ValidationContext) {
-  const { scope, component, path } = context;
-  const absolutePath = getComponentAbsolutePath(component) || path;
+  const { scope, path } = context;
   if (error) {
     const cleanedError = cleanupValidationError(error);
-    cleanedError.context.path = absolutePath;
+    cleanedError.context.path = path;
     if (
       !find(scope.errors, {
         errorKeyOrMessage: cleanedError.errorKeyOrMessage,
         context: {
-          path: absolutePath,
+          path: path,
         },
       })
     ) {
       if (!scope.validated) scope.validated = [];
       if (!scope.errors) scope.errors = [];
       scope.errors.push(cleanedError);
-      scope.validated.push({ path: absolutePath, error: cleanedError });
+      scope.validated.push({ path, error: cleanedError });
     }
   }
 }

--- a/src/process/validation/rules/__tests__/fixtures/util.ts
+++ b/src/process/validation/rules/__tests__/fixtures/util.ts
@@ -11,9 +11,15 @@ export const generateProcessorContext = (
   return {
     component,
     data,
-    form,
+    form: form ? form : { components: [component] },
     scope: { errors: [] },
     row: data,
+    paths: {
+      path: component.key,
+      localPath: component.key,
+      fullPath: component.key,
+      fullLocalPath: component.key,
+    },
     path: component.key,
     value,
     config: {

--- a/src/process/validation/rules/__tests__/validateAvailableItems.test.ts
+++ b/src/process/validation/rules/__tests__/validateAvailableItems.test.ts
@@ -608,7 +608,7 @@ describe('validateAvailableItems', function () {
         baz: true,
         biz: false,
         new: true,
-        test: false
+        test: false,
       },
     };
     const context = generateProcessorContext(component, data);
@@ -631,7 +631,7 @@ describe('validateAvailableItems', function () {
       component: {
         one: true,
         two: false,
-        three: true
+        three: true,
       },
     };
     const context = generateProcessorContext(component, data);
@@ -639,8 +639,7 @@ describe('validateAvailableItems', function () {
     context.fetch = () => {
       return Promise.resolve({
         ok: true,
-        json: () =>
-          Promise.resolve(['one', 'two', 'three']),
+        json: () => Promise.resolve(['one', 'two', 'three']),
       });
     };
     const result = await validateAvailableItems(context);
@@ -663,7 +662,7 @@ describe('validateAvailableItems', function () {
         two: false,
         three: true,
         four: true,
-        five: false
+        five: false,
       },
     };
     const context = generateProcessorContext(component, data);
@@ -671,8 +670,7 @@ describe('validateAvailableItems', function () {
     context.fetch = () => {
       return Promise.resolve({
         ok: true,
-        json: () =>
-          Promise.resolve(['one', 'two', 'three']),
+        json: () => Promise.resolve(['one', 'two', 'three']),
       });
     };
     const result = await validateAvailableItems(context);

--- a/src/process/validation/rules/__tests__/validateRequired.test.ts
+++ b/src/process/validation/rules/__tests__/validateRequired.test.ts
@@ -15,6 +15,7 @@ import { processOne } from 'processes/processOne';
 import { generateProcessorContext } from './fixtures/util';
 import { ProcessorsContext, SelectBoxesComponent, ValidationScope } from 'types';
 import { validateProcessInfo } from 'processes/validation';
+import { conditionProcessInfo } from 'processes/conditions';
 
 describe('validateRequired', function () {
   it('Validating a simple component that is required and not present in the data will return a field error', async function () {
@@ -66,7 +67,7 @@ describe('validateRequired', function () {
     const component = conditionallyHiddenRequiredHiddenField;
     const data = { otherData: 'hideme' };
     const context = generateProcessorContext(component, data) as ProcessorsContext<ValidationScope>;
-    context.processors = [validateProcessInfo];
+    context.processors = [conditionProcessInfo, validateProcessInfo];
     await processOne(context);
     expect(context.scope.errors.length).to.equal(0);
   });

--- a/src/process/validation/rules/__tests__/validateRequiredDay.test.ts
+++ b/src/process/validation/rules/__tests__/validateRequiredDay.test.ts
@@ -59,7 +59,7 @@ describe('validateRequiredDay', function () {
       fields: {
         year: { required: true },
         month: { required: true },
-        day: { hide: true }
+        day: { hide: true },
       },
     };
     const data = { component: '07/2024' };
@@ -74,7 +74,7 @@ describe('validateRequiredDay', function () {
       fields: {
         year: { required: true },
         day: { required: true },
-        month: { hide: true }
+        month: { hide: true },
       },
     };
     const data = { component: '24/2024' };
@@ -89,7 +89,7 @@ describe('validateRequiredDay', function () {
       fields: {
         month: { required: true },
         day: { required: true },
-        year: { hide: true }
+        year: { hide: true },
       },
     };
     const data = { component: '07/24' };

--- a/src/process/validation/rules/__tests__/validateValueProperty.test.ts
+++ b/src/process/validation/rules/__tests__/validateValueProperty.test.ts
@@ -2,10 +2,7 @@ import { expect } from 'chai';
 import { set } from 'lodash';
 import { FieldError } from 'error';
 import { SelectBoxesComponent } from 'types';
-import {
-  simpleRadioField,
-  simpleSelectBoxes
-} from './fixtures/components';
+import { simpleRadioField, simpleSelectBoxes } from './fixtures/components';
 import { generateProcessorContext } from './fixtures/util';
 import { validateValueProperty } from '../validateValueProperty';
 
@@ -45,7 +42,7 @@ describe('validateValueProperty', function () {
         headers: [],
       },
     };
-    const data = {component: { 'true': true }};
+    const data = { component: { true: true } };
 
     const context = generateProcessorContext(component, data);
     const result = await validateValueProperty(context);
@@ -62,7 +59,7 @@ describe('validateValueProperty', function () {
         headers: [],
       },
     };
-    const data =  {component: { 'true': true }};
+    const data = { component: { true: true } };
 
     const context = generateProcessorContext(component, data);
     set(context, 'instance.options.building', true);

--- a/src/process/validation/rules/validateAvailableItems.ts
+++ b/src/process/validation/rules/validateAvailableItems.ts
@@ -28,11 +28,7 @@ function isValidateableSelectComponent(component: any): component is SelectCompo
 }
 
 function isValidateableSelectBoxesComponent(component: any): component is SelectBoxesComponent {
-  return (
-    component &&
-    !!component.validate?.onlyAvailableItems &&
-    component.type === 'selectboxes'
-  );
+  return component && !!component.validate?.onlyAvailableItems && component.type === 'selectboxes';
 }
 
 function mapDynamicValues<T extends Record<string, any>>(component: SelectComponent, values: T[]) {
@@ -279,11 +275,9 @@ export const validateAvailableItems: RuleFn = async (context: ValidationContext)
       const values =
         component.dataSrc === 'url'
           ? await getAvailableDynamicValues(component, context)
-          : component.values.map(val => val.value);
+          : component.values.map((val) => val.value);
       if (values) {
-        return difference(Object.keys(value), values).length
-          ? error
-          : null;
+        return difference(Object.keys(value), values).length ? error : null;
       }
     }
   } catch (err: any) {
@@ -340,11 +334,9 @@ export const validateAvailableItemsSync: RuleFnSync = (context: ValidationContex
         return null;
       }
 
-      const values = component.values.map(val => val.value);
+      const values = component.values.map((val) => val.value);
       if (values) {
-        return difference(Object.keys(value), values).length
-          ? error
-          : null;
+        return difference(Object.keys(value), values).length ? error : null;
       }
     }
   } catch (err: any) {

--- a/src/process/validation/rules/validateCustom.ts
+++ b/src/process/validation/rules/validateCustom.ts
@@ -1,6 +1,7 @@
 import { RuleFn, RuleFnSync, ProcessorInfo, ValidationContext } from 'types';
 import { FieldError, ProcessorError } from 'error';
 import { Evaluator } from 'utils';
+import { normalizeContext } from 'utils/formUtil';
 
 export const validateCustom: RuleFn = async (context: ValidationContext) => {
   return validateCustomSync(context);
@@ -27,8 +28,8 @@ export const validateCustomSync: RuleFnSync = (context: ValidationContext) => {
       ...(instance?.evalContext
         ? instance.evalContext()
         : evalContext
-          ? evalContext(context)
-          : context),
+          ? evalContext(normalizeContext(context))
+          : normalizeContext(context)),
       component,
       data,
       row,

--- a/src/process/validation/rules/validateJson.ts
+++ b/src/process/validation/rules/validateJson.ts
@@ -3,6 +3,7 @@ import { FieldError } from 'error';
 import { RuleFn, RuleFnSync, ValidationContext } from 'types';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 import { isObject } from 'lodash';
+import { normalizeContext } from 'utils/formUtil';
 
 export const shouldValidate = (context: ValidationContext) => {
   const { component } = context;
@@ -23,7 +24,9 @@ export const validateJsonSync: RuleFnSync = (context: ValidationContext) => {
   }
 
   const func = component?.validate?.json;
-  const evalContextValue = evalContext ? evalContext(context) : context;
+  const evalContextValue = evalContext
+    ? evalContext(normalizeContext(context))
+    : normalizeContext(context);
   evalContextValue.value = value || null;
   const valid: true | string = JSONLogicEvaluator.evaluate(
     func,

--- a/src/process/validation/rules/validateValueProperty.ts
+++ b/src/process/validation/rules/validateValueProperty.ts
@@ -3,15 +3,11 @@ import { ListComponent, RuleFn, RuleFnSync, ValidationContext } from 'types';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 
 const isValidatableListComponent = (comp: any): comp is ListComponent => {
-  return (
-    comp &&
-    comp.type &&
-    comp.type === 'selectboxes'
-  );
+  return comp && comp.type && comp.type === 'selectboxes';
 };
 
 export const shouldValidate = (context: ValidationContext) => {
-  const { component, instance} = context;
+  const { component, instance } = context;
   if (!isValidatableListComponent(component)) {
     return false;
   }
@@ -39,7 +35,7 @@ export const validateValuePropertySync: RuleFnSync = (context: ValidationContext
     Object.entries(value as any).some(
       ([key, value]) => value && (key === '[object Object]' || key === 'true' || key === 'false'),
     ) ||
-    (instance && instance.loadedOptions?.some(option => option.invalid))
+    (instance && instance.loadedOptions?.some((option) => option.invalid))
   ) {
     return error;
   }

--- a/src/process/validation/util.ts
+++ b/src/process/validation/util.ts
@@ -1,5 +1,5 @@
 import { FieldError } from 'error';
-import { Component, ValidationContext } from 'types';
+import { Component } from 'types';
 import { Evaluator, unescapeHTML } from 'utils';
 import { VALIDATION_ERRORS } from './i18n';
 import _isEmpty from 'lodash/isEmpty';
@@ -16,12 +16,6 @@ export function isComponentProtected(component: Component) {
 
 export function isEmptyObject(obj: any) {
   return !!obj && Object.keys(obj).length === 0 && obj.constructor === Object;
-}
-
-export function getComponentErrorField(component: Component, context: ValidationContext) {
-  const toInterpolate =
-    component.errorLabel || component.label || component.placeholder || component.key;
-  return Evaluator.interpolate(toInterpolate, context);
 }
 
 export function toBoolean(value: any) {

--- a/src/sdk/__tests__/Formio.test.ts
+++ b/src/sdk/__tests__/Formio.test.ts
@@ -1896,6 +1896,7 @@ describe('Formio.js Tests', function () {
                     submissionAccess: [],
                     components: [
                       {
+                        type: 'hidden',
                         defaultPermission: 'read',
                         key: 'groupField',
                       },
@@ -1952,6 +1953,7 @@ describe('Formio.js Tests', function () {
                     submissionAccess: [],
                     components: [
                       {
+                        type: 'hidden',
                         defaultPermission: 'create',
                         key: 'groupField',
                       },
@@ -2008,6 +2010,7 @@ describe('Formio.js Tests', function () {
                     submissionAccess: [],
                     components: [
                       {
+                        type: 'hidden',
                         defaultPermission: 'write',
                         key: 'groupField',
                       },
@@ -2064,6 +2067,7 @@ describe('Formio.js Tests', function () {
                     submissionAccess: [],
                     components: [
                       {
+                        type: 'hidden',
                         defaultPermission: 'admin',
                         key: 'groupField',
                       },
@@ -2136,6 +2140,7 @@ describe('Formio.js Tests', function () {
                     submissionAccess: [],
                     components: [
                       {
+                        type: 'hidden',
                         defaultPermission: 'read',
                         key: 'groupField',
                       },

--- a/src/types/BaseComponent.ts
+++ b/src/types/BaseComponent.ts
@@ -14,12 +14,15 @@ export type SimpleConditional = {
   conditions: SimpleConditionalConditions;
 };
 
+export type ComponentScope = {
+  conditionallyHidden?: boolean;
+};
+
 export type BaseComponent = {
   input: boolean;
   type: string;
   key: string;
-  path?: string;
-  parent?: BaseComponent;
+  path?: string; // The "form" path to the component including non-layout parent components.
   tableView?: boolean;
   placeholder?: string;
   prefix?: string;
@@ -31,9 +34,7 @@ export type BaseComponent = {
   unique?: boolean;
   persistent?: boolean | string;
   hidden?: boolean;
-  ephemeralState?: {
-    conditionallyHidden?: boolean;
-  };
+  scope?: ComponentScope;
   clearOnHide?: boolean;
   refreshOn?: string;
   redrawOn?: string;
@@ -59,7 +60,6 @@ export type BaseComponent = {
   validateOn?: string;
   validateWhenHidden?: boolean;
   modelType?: ReturnType<typeof getModelType>;
-  parentPath?: string;
   validate?: {
     required?: boolean;
     custom?: string;

--- a/src/types/PassedComponentInstance.ts
+++ b/src/types/PassedComponentInstance.ts
@@ -19,5 +19,5 @@ export type PassedComponentInstance = {
   evaluate: (expression: string, additionalContext?: Record<string, any>) => any;
   interpolate: (text: string, additionalContext?: Record<string, any>) => string;
   shouldSkipValidation: (data?: DataObject, row?: DataObject) => boolean;
-  loadedOptions?: Array<{invalid: boolean, value: any, label: string}>
+  loadedOptions?: Array<{ invalid: boolean; value: any; label: string }>;
 };

--- a/src/types/formUtil.ts
+++ b/src/types/formUtil.ts
@@ -1,4 +1,139 @@
-import { Component, DataObject } from 'types';
+import { Component } from './Component';
+import { DataObject } from './DataObject';
+
+/**
+ * Defines the Component paths used for every component within a form. This allows for
+ * quick reference to either the "form" path or the "data" path of a component. These paths are
+ * defined as follows.
+ *
+ *  - Form Path: The path to a component within the Form JSON. This path is used to locate a component provided a nested Form JSON object.
+ *  - Data Path: The path to the data value of a component within the data model for the form. This path is used to provide the value path provided the Submission JSON object.
+ *
+ * These paths can also be broken into two different path "types".   Local and Full paths.
+ *
+ *  - Local Path: This is the path relative to the "current" form. This is used inside of a nested form to identify components and values relative to the current form in context.
+ *  - Full Path: This is the path that is absolute to the root form object. Any nested form paths will include the parent form path as part of the value for the provided path.
+ */
+export enum ComponentPath {
+  /**
+   * The "form" path to the component including all parent paths (exclusive of layout components). This path is used to uniquely identify component within a form inclusive of any parent form paths.
+   *
+   * For example: Suppose you have the following form structure.
+   *    - Root
+   *      - Panel 1 (panel)
+   *        - Form (form)
+   *          - Panel 2 (panel2)
+   *            - Data Grid (dataGrid)
+   *              - Panel 3 (panel3)
+   *                - TextField (textField)
+   *
+   * The "path" to the TextField component from the perspective of a configuration within the Form, would be "form.dataGrid.textField"
+   */
+  path = 'path',
+
+  /**
+   * The "form" path to the component including all parent paths (inclusive of layout componnts). This path is used to uniquely identify component within a form inclusive of any parent form paths.
+   *
+   * For example: Suppose you have the following form structure.
+   *    - Root
+   *      - Panel 1 (panel)
+   *        - Form (form)
+   *          - Panel 2 (panel2)
+   *            - Data Grid (dataGrid)
+   *              - Panel 3 (panel3)
+   *                - TextField (textField)
+   *
+   * The "fullPath" to the TextField component from the perspective of a configuration within the Form, would be "panel1.form.panel2.dataGrid.panel3.textField"
+   */
+  fullPath = 'fullPath',
+
+  /**
+   * The local "form" path to the component. This is the local path to any component within a form. This
+   * path is consistent no matter if this form is nested within another form or not. All form configurations
+   * are in relation to this path since forms are configured independently. The difference between a form path
+   * and a dataPath is that this includes any parent layout components to locate the component provided a form JSON.
+   * This path does NOT include any layout components.
+   *
+   * For example: Suppose you have the following form structure.
+   *    - Root
+   *      - Panel 1 (panel)
+   *        - Form (form)
+   *          - Panel 2 (panel2)
+   *            - Data Grid (dataGrid)
+   *              - Panel 3 (panel3)
+   *                - TextField (textField)
+   *
+   * The "path" to the TextField component from the perspective of a configuration within the Form, would be "dataGrid.textField"
+   */
+  localPath = 'localPath',
+
+  /**
+   * The local "form" path to the component. This is the local path to any component within a form. This
+   * path is consistent no matter if this form is nested within another form or not. All form configurations
+   * are in relation to this path since forms are configured independently. The difference between a form path
+   * and a dataPath is that this includes any parent layout components to locate the component provided a form JSON.
+   * This path does NOT include any layout components.
+   *
+   * For example: Suppose you have the following form structure.
+   *    - Root
+   *      - Panel 1 (panel)
+   *        - Form (form)
+   *          - Panel 2 (panel2)
+   *            - Data Grid (dataGrid)
+   *              - Panel 3 (panel3)
+   *                - TextField (textField)
+   *
+   * The "path" to the TextField component from the perspective of a configuration within the Form, would be "panel2.dataGrid.panel3.textField"
+   */
+  fullLocalPath = 'fullLocalPath',
+
+  /**
+   *  The "data" path to the component including all parent paths. This path is used to fetch the data value of a component within a data model, inclusive of any parent data paths of nested forms.
+   *
+   * For example: Suppose you have the following form structure.
+   *    - Root
+   *      - Panel 1 (panel)
+   *        - Form (form)
+   *          - Panel 2 (panel2)
+   *            - Data Grid (dataGrid)
+   *              - Panel 3 (panel3)
+   *                - TextField (textField)
+   *
+   * The "dataPath" to the TextField component would be "form.data.dataGrid[1].textField"
+   */
+  dataPath = 'dataPath',
+
+  /**
+   * The "data" path is the local path to the data value for any component. The difference between this path
+   * and the "path" is that this path is used to locate the data value for a component within the data model.
+   * and does not include any keys for layout components.
+   *
+   * For example: Suppose you have the following form structure.
+   *    - Root
+   *      - Panel 1 (panel)
+   *        - Form (form)
+   *          - Panel 2 (panel2)
+   *            - Data Grid (dataGrid)
+   *              - Panel 3 (panel3)
+   *                - TextField (textField)
+   *
+   * The "localDataPath" to the TextField component from the perspective of a configuration within the Form, would be "dataGrid[1].textField"
+   */
+  localDataPath = 'localDataPath',
+}
+
+/**
+ * The types of paths that can be set on a component.
+ */
+export type ComponentPaths = {
+  path?: string;
+  fullPath?: string;
+  localPath?: string;
+  fullLocalPath?: string;
+  dataPath?: string;
+  localDataPath?: string;
+  dataIndex?: number;
+};
 
 export type EachComponentDataAsyncCallback = (
   component: Component,
@@ -8,6 +143,7 @@ export type EachComponentDataAsyncCallback = (
   components?: Component[],
   index?: number,
   parent?: Component | null,
+  paths?: ComponentPaths,
 ) => Promise<boolean | void>;
 
 export type EachComponentDataCallback = (
@@ -18,6 +154,7 @@ export type EachComponentDataCallback = (
   components?: Component[],
   index?: number,
   parent?: Component | null,
+  paths?: ComponentPaths,
 ) => boolean | void;
 
 export type EachComponentCallback = (
@@ -25,6 +162,15 @@ export type EachComponentCallback = (
   path: string,
   components?: Component[],
   parent?: Component,
+  paths?: ComponentPaths,
 ) => boolean | void;
+
+export type EachComponentAsyncCallback = (
+  component: Component,
+  path: string,
+  components?: Component[],
+  parent?: Component,
+  paths?: ComponentPaths,
+) => Promise<boolean | void>;
 
 export type FetchFn = (url: string, options?: RequestInit) => Promise<any>;

--- a/src/types/process/ProcessContext.ts
+++ b/src/types/process/ProcessContext.ts
@@ -5,6 +5,7 @@ import {
   ProcessorContext,
   ProcessType,
   ProcessorInfo,
+  ComponentPaths,
 } from 'types';
 
 export type ComponentInstances = {
@@ -21,6 +22,9 @@ export type BaseProcessContext<ProcessorScope> = {
   form?: any;
   submission?: any;
   flat?: boolean;
+  parent?: Component;
+  parentPaths?: ComponentPaths;
+  local?: boolean; // If the "data" being passed to the processors is local to the nested form.
   evalContext?: (context: ProcessorContext<ProcessorScope>) => any;
 };
 

--- a/src/types/process/ProcessorContext.ts
+++ b/src/types/process/ProcessorContext.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  ComponentPaths,
   DataObject,
   Form,
   PassedComponentInstance,
@@ -16,6 +17,7 @@ export type ProcessorContext<ProcessorScope> = {
   row: any;
   value?: any;
   form?: Form;
+  paths?: ComponentPaths;
   submission?: Submission;
   components?: Component[];
   instance?: PassedComponentInstance;
@@ -23,6 +25,7 @@ export type ProcessorContext<ProcessorScope> = {
   processor?: ProcessorType;
   config?: Record<string, any>;
   index?: number;
+  local?: boolean; // If the "data" being passed to the processors is local to the nested form.
   scope: ProcessorScope;
   parent?: Component | null;
   evalContext?: (context: ProcessorContext<ProcessorScope>) => any;

--- a/src/types/process/populate/PopulateScope.ts
+++ b/src/types/process/populate/PopulateScope.ts
@@ -4,6 +4,5 @@ export type PopulateScope = {
   row?: any;
   populated?: Array<{
     path: string;
-    row: any;
   }>;
 } & ProcessorScope;

--- a/src/utils/Evaluator.ts
+++ b/src/utils/Evaluator.ts
@@ -5,6 +5,12 @@ export interface EvaluatorOptions {
   data?: any;
 }
 
+export type EvaluatorContext = {
+  evalContext?: (context: any) => any;
+  instance?: any;
+  [key: string]: any;
+};
+
 // BaseEvaluator is for extending.
 export class BaseEvaluator {
   static templateSettings = {

--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -12,7 +12,7 @@ import {
   findComponents,
   getComponent,
   flattenComponents,
-  getComponentActualValue,
+  getComponentValue,
   hasCondition,
   getModelType,
 } from '../formUtil';
@@ -109,16 +109,14 @@ describe('formUtil', function () {
           },
         },
       };
-      const path = 'a.b.c';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'c',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'c',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a.b.c',
+      });
       const expected = { c: 'hello' };
       expect(actual).to.deep.equal(expected);
     });
@@ -131,16 +129,14 @@ describe('formUtil', function () {
           },
         },
       };
-      const path = 'a.b';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'b',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'b',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a.b',
+      });
       const expected = { b: { c: 'hello' } };
       expect(actual).to.deep.equal(expected);
     });
@@ -153,16 +149,14 @@ describe('formUtil', function () {
           },
         },
       };
-      const path = 'a';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'a',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'a',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a',
+      });
       const expected = { a: { b: { c: 'hello' } } };
       expect(actual).to.deep.equal(expected);
     });
@@ -176,16 +170,12 @@ describe('formUtil', function () {
         },
         d: 'there',
       };
-      const path = '';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'd',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'd',
+      };
+      const actual = getContextualRowData(component, data);
       const expected = { a: { b: { c: 'hello' } }, d: 'there' };
       expect(actual).to.deep.equal(expected);
     });
@@ -197,16 +187,14 @@ describe('formUtil', function () {
           { b: 'foo', c: 'bar' },
         ],
       };
-      const path = 'a[0].b';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'b',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'b',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a[0].b',
+      });
       const expected = { b: 'hello', c: 'world' };
       expect(actual).to.deep.equal(expected);
     });
@@ -218,16 +206,14 @@ describe('formUtil', function () {
           { b: 'foo', c: 'bar' },
         ],
       };
-      const path = 'a[1].b';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'b',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'b',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a[1].b',
+      });
       const expected = { b: 'foo', c: 'bar' };
       expect(actual).to.deep.equal(expected);
     });
@@ -239,16 +225,14 @@ describe('formUtil', function () {
           { b: 'foo', c: 'bar' },
         ],
       };
-      const path = 'a';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'a',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'a',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a',
+      });
       const expected = {
         a: [
           { b: 'hello', c: 'world' },
@@ -265,16 +249,12 @@ describe('formUtil', function () {
           { b: 'foo', c: 'bar' },
         ],
       };
-      const path = '';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'a',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'a',
+      };
+      const actual = getContextualRowData(component, data);
       const expected = {
         a: [
           { b: 'hello', c: 'world' },
@@ -293,16 +273,14 @@ describe('formUtil', function () {
           ],
         },
       };
-      const path = 'a.b[0].c';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'c',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'c',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a.b[0].c',
+      });
       const expected = { c: 'hello', d: 'world' };
       expect(actual).to.deep.equal(expected);
     });
@@ -316,16 +294,14 @@ describe('formUtil', function () {
           ],
         },
       };
-      const path = 'a.b[1].c';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'c',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'c',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a.b[1].c',
+      });
       const expected = { c: 'foo', d: 'bar' };
       expect(actual).to.deep.equal(expected);
     });
@@ -339,16 +315,14 @@ describe('formUtil', function () {
           ],
         },
       };
-      const path = 'a.b';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'b',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'b',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a.b',
+      });
       const expected = {
         b: [
           { c: 'hello', d: 'world' },
@@ -367,16 +341,14 @@ describe('formUtil', function () {
           ],
         },
       };
-      const path = 'a';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'a',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'a',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a',
+      });
       const expected = {
         a: {
           b: [
@@ -397,16 +369,12 @@ describe('formUtil', function () {
           ],
         },
       };
-      const path = '';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'a',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'a',
+      };
+      const actual = getContextualRowData(component, data);
       const expected = {
         a: {
           b: [
@@ -427,16 +395,14 @@ describe('formUtil', function () {
           ],
         },
       };
-      const path = 'a.b[0].c.e';
-      const actual = getContextualRowData(
-        {
-          type: 'textfield',
-          input: true,
-          key: 'c.e',
-        },
-        path,
-        data,
-      );
+      const component = {
+        type: 'textfield',
+        input: true,
+        key: 'c.e',
+      };
+      const actual = getContextualRowData(component, data, {
+        dataPath: 'a.b[0].c.e',
+      });
       const expected = { c: { e: 'zed' }, d: 'world' };
       expect(actual).to.deep.equal(expected);
     });
@@ -711,9 +677,6 @@ describe('formUtil', function () {
           const value = get(data, path);
           rowResults.set(path, [component, value]);
         },
-        undefined,
-        undefined,
-        undefined,
         true,
       );
       expect(rowResults.size).to.equal(2);
@@ -822,7 +785,7 @@ describe('formUtil', function () {
                 tableView: true,
               },
               {
-                type: 'editGrid',
+                type: 'editgrid',
                 key: 'nestedEditGrid',
                 input: true,
                 tableView: true,
@@ -1478,9 +1441,6 @@ describe('formUtil', function () {
           const value = get(data, path);
           rowResults.set(path, [component, value]);
         },
-        undefined,
-        undefined,
-        undefined,
         true,
       );
       expect(rowResults.size).to.equal(2);
@@ -1505,49 +1465,65 @@ describe('formUtil', function () {
     });
   });
 
-  describe('getComponentActualValue', function () {
+  describe('getComponentValue', function () {
     it('Should return correct value for component inside inside panel inside editGrid', function () {
-      const component = {
-        label: 'Radio',
-        optionsLabelPosition: 'right',
-        inline: false,
-        tableView: false,
-        values: [
-          { label: 'yes', value: 'yes', shortcut: '' },
-          { label: 'no', value: 'no', shortcut: '' },
-        ],
-        key: 'radio',
-        type: 'radio',
-        input: true,
-        path: 'editGrid.radio',
-        parent: {
-          collapsible: false,
-          key: 'panel',
-          type: 'panel',
-          label: 'Panel',
-          input: false,
-          tableView: false,
-          path: 'editGrid[0].panel',
-          parent: {
-            label: 'Edit Grid',
-            tableView: false,
-            rowDrafts: false,
-            key: 'editGrid',
-            type: 'editgrid',
-            path: 'editGrid',
-            displayAsTable: false,
-            input: true,
-          },
-        },
-      };
       const compPath = 'editGrid.radio';
       const data = {
-        editGrid: [{ radio: 'yes', textArea: 'test' }],
+        form: {
+          data: {
+            editGrid: [{ radio: 'yes', textArea: 'test' }],
+          },
+        },
         submit: true,
       };
-      const row = { radio: 'yes', textArea: 'test' };
-
-      const value = getComponentActualValue(component, compPath, data, row);
+      const value = getComponentValue(
+        {
+          components: [
+            {
+              type: 'panel',
+              label: 'Panel',
+              key: 'panel',
+              input: false,
+              components: [
+                {
+                  type: 'form',
+                  key: 'form',
+                  input: false,
+                  components: [
+                    {
+                      type: 'panel',
+                      key: 'panel',
+                      label: 'Panel',
+                      input: false,
+                      components: [
+                        {
+                          type: 'editgrid',
+                          key: 'editGrid',
+                          input: true,
+                          components: [
+                            {
+                              type: 'radio',
+                              key: 'radio',
+                              label: 'Radio',
+                              input: true,
+                              values: [
+                                { label: 'yes', value: 'yes', shortcut: '' },
+                                { label: 'no', value: 'no', shortcut: '' },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        data,
+        compPath,
+      );
       expect(value).to.equal('yes');
     });
   });

--- a/src/utils/formUtil/__tests__/eachComponent.test.ts
+++ b/src/utils/formUtil/__tests__/eachComponent.test.ts
@@ -1041,4 +1041,45 @@ describe('eachComponent', function () {
     );
     expect(contentComponentsAmount).to.be.equal(1);
   });
+
+  it('Should get the absolute paths correctly when iterating.', function () {
+    const form: any = {
+      key: 'form',
+      display: 'form',
+      components: [
+        {
+          type: 'container',
+          key: 'outer-container',
+          components: [
+            {
+              type: 'textfield',
+              key: 'textfield',
+            },
+            {
+              type: 'container',
+              key: 'inner-container',
+              components: [
+                {
+                  type: 'textfield',
+                  key: 'innerTextfield',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    // when passed child components, absolute path returns relative to the parent component/
+    eachComponent(
+      form.components,
+      (component: Component, path: string, components, parent, paths) => {
+        if (component.key === 'innerTextfield') {
+          expect(paths?.dataPath).to.equal(
+            'outer-container.inner-container.innerTextfield',
+            'absolute path path is incomplete',
+          );
+        }
+      },
+    );
+  });
 });

--- a/src/utils/formUtil/__tests__/eachComponent.test.ts
+++ b/src/utils/formUtil/__tests__/eachComponent.test.ts
@@ -666,18 +666,18 @@ describe('eachComponent', function () {
     expect(numComps).to.be.equal(8);
   });
 
-  it('Should provide the paths to all of the components', function () {
+  it('Should provide the paths to all of the components if includeAll=true', function () {
     const paths = [
       'one',
       'parent1',
-      'two',
-      'parent2',
-      'three',
-      '',
-      'four',
-      'five',
-      'six',
-      'seven',
+      'parent1.two',
+      'parent1.parent2',
+      'parent1.parent2.three',
+      'parent1.parent2',
+      'parent1.parent2.four',
+      'parent1.parent2.five',
+      'parent1.parent2.six',
+      'parent1.parent2.seven',
       'eight',
     ];
     const testPaths: string[] = [];
@@ -879,14 +879,13 @@ describe('eachComponent', function () {
     ];
     const rowResults: Map<string, any> = new Map();
     eachComponent(
-      components[0].components,
+      components,
       (component: Component, path: string) => {
         rowResults.set(path, component);
       },
       true,
-      'dataGrid',
     );
-    expect(rowResults.size).to.equal(2);
+    expect(rowResults.size).to.equal(3);
     expect(rowResults.get('dataGrid.nestedTextField')).to.deep.equal({
       type: 'textfield',
       key: 'nestedTextField',
@@ -903,14 +902,14 @@ describe('eachComponent', function () {
     const paths = [
       'a',
       'b',
-      'c',
-      'd',
-      'f',
-      'f.g',
-      'f.h',
-      'f.i',
-      'e',
-      'j',
+      'b.c',
+      'b.c.d',
+      'b.c.f',
+      'b.c.f.g',
+      'b.c.f.h',
+      'b.c.f.i',
+      'b.c.e',
+      'b.j',
       'k',
       'k.n',
       'k.n.o',
@@ -1041,58 +1040,5 @@ describe('eachComponent', function () {
       true,
     );
     expect(contentComponentsAmount).to.be.equal(1);
-  });
-
-  it('should not mutate the path property if contained in component', function () {
-    const components = [
-      {
-        type: 'textfield',
-        key: 'textField',
-        input: true,
-        path: 'doNotMutate',
-      },
-      {
-        type: 'container',
-        key: 'container',
-        input: true,
-        path: 'doNotMutate',
-        components: [
-          {
-            type: 'textfield',
-            key: 'nestedTextField',
-            path: 'doNotMutate',
-            input: true,
-          },
-          {
-            type: 'textarea',
-            key: 'nestedTextArea',
-            path: 'doNotMutate',
-            input: true,
-          },
-        ],
-      },
-    ];
-    eachComponent(
-      components,
-      (component: Component, path: string) => {
-        if (component.key === 'textField') {
-          expect(component.path).to.equal('doNotMutate');
-          expect(path).to.equal('textField');
-        }
-        if (component.key === 'container') {
-          expect(component.path).to.equal('doNotMutate');
-          expect(path).to.equal('container');
-        }
-        if (component.key === 'nestedTextField') {
-          expect(component.path).to.equal('doNotMutate');
-          expect(path).to.equal('container.nestedTextField');
-        }
-        if (component.key === 'nestedTextArea') {
-          expect(component.path).to.equal('doNotMutate');
-          expect(path).to.equal('container.nestedTextArea');
-        }
-      },
-      true,
-    );
   });
 });

--- a/src/utils/formUtil/__tests__/index.test.ts
+++ b/src/utils/formUtil/__tests__/index.test.ts
@@ -1,0 +1,20 @@
+import { assert } from 'chai';
+import { getComponentLocalData } from '../index';
+describe('Form Utils', function () {
+  it('getComponentLocalData', function () {
+    assert.deepEqual(
+      getComponentLocalData(
+        {
+          dataPath: 'firstName',
+          localDataPath: 'firstName',
+        },
+        {
+          firstName: 'Joe',
+        },
+      ),
+      {
+        firstName: 'Joe',
+      } as any,
+    );
+  });
+});

--- a/src/utils/formUtil/eachComponentData.ts
+++ b/src/utils/formUtil/eachComponentData.ts
@@ -1,5 +1,4 @@
-import { isEmpty, get, set, has } from 'lodash';
-
+import { get } from 'lodash';
 import {
   Component,
   DataObject,
@@ -7,143 +6,144 @@ import {
   HasChildComponents,
   HasColumns,
   HasRows,
+  ComponentPaths,
 } from 'types';
 import {
-  getContextualRowData,
   isComponentNestedDataType,
-  getModelType,
-  componentDataPath,
   componentInfo,
-  componentFormPath,
+  getContextualRowData,
+  shouldProcessComponent,
+  resetComponentScope,
+  getModelType,
 } from './index';
 import { eachComponent } from './eachComponent';
 
+/**
+ * Iterates through each component as well as its data, and triggers a callback for every component along
+ * with the contextual data for that component in addition to the absolute path for that component.
+ * @param components - The array of JSON components to iterate through.
+ * @param data - The contextual data object for the components.
+ * @param fn - The callback function to trigger for each component following the signature (component, data, row, path, components, index, parent).
+ * @param parent - The parent component.
+ * @param includeAll
+ * @returns
+ */
 export const eachComponentData = (
   components: Component[],
   data: DataObject,
   fn: EachComponentDataCallback,
-  path = '',
-  index?: number,
-  parent?: Component,
   includeAll: boolean = false,
+  local: boolean = false,
+  parent?: Component,
+  parentPaths?: ComponentPaths,
 ) => {
   if (!components) {
     return;
   }
   return eachComponent(
     components,
-    (component, compPath, componentComponents, compParent) => {
-      const row = getContextualRowData(component, compPath, data);
-      if (fn(component, data, row, compPath, componentComponents, index, compParent) === true) {
+    (component, compPath, componentComponents, compParent, compPaths) => {
+      const row = getContextualRowData(component, data, compPaths, local);
+      if (
+        fn(
+          component,
+          data,
+          row,
+          compPaths?.dataPath || '',
+          componentComponents,
+          compPaths?.dataIndex,
+          compParent,
+          compPaths,
+        ) === true
+      ) {
+        resetComponentScope(component);
         return true;
       }
       if (isComponentNestedDataType(component)) {
-        const value = get(data, compPath, data) as DataObject;
-        if (Array.isArray(value)) {
-          for (let i = 0; i < value.length; i++) {
-            const nestedComponentPath =
-              getModelType(component) === 'nestedDataArray'
-                ? `${compPath}[${i}].data`
-                : `${compPath}[${i}]`;
-            eachComponentData(
-              component.components,
-              data,
-              fn,
-              nestedComponentPath,
-              i,
-              component,
-              includeAll,
-            );
+        const value = get(
+          data,
+          local ? compPaths?.localDataPath || '' : compPaths?.dataPath || '',
+        ) as DataObject;
+        if (
+          getModelType(component) === 'nestedArray' ||
+          getModelType(component) === 'nestedDataArray'
+        ) {
+          if (Array.isArray(value) && value.length) {
+            for (let i = 0; i < value.length; i++) {
+              if (compPaths) {
+                compPaths.dataIndex = i;
+              }
+              eachComponentData(
+                component.components,
+                data,
+                fn,
+                includeAll,
+                local,
+                component,
+                compPaths,
+              );
+            }
           }
+          resetComponentScope(component);
           return true;
-        } else if (isEmpty(row) && !includeAll) {
-          // Tree components may submit empty objects; since we've already evaluated the parent tree/layout component, we won't worry about constituent elements
-          return true;
-        }
-        if (getModelType(component) === 'dataObject') {
-          const nestedFormValue: any = get(data, component.path);
-          const noReferenceAttached = nestedFormValue?._id
-            ? isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form')
-            : false;
-          const shouldBeCleared =
-            (!component.hasOwnProperty('clearOnHide') || component.clearOnHide) &&
-            (component.hidden || component.ephemeralState?.conditionallyHidden);
-          // Skip all the nested components processing if nested form is hidden and should be cleared on hide or if submission is saved as reference and not loaded
-          const shouldSkipProcessingNestedFormData = noReferenceAttached || shouldBeCleared;
-          if (!shouldSkipProcessingNestedFormData) {
-            // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
-            const childPath: string = componentDataPath(component, path, compPath);
-            const childData: any = get(data, childPath, {});
-            eachComponentData(
-              component.components,
-              childData,
-              fn,
-              '',
-              index,
-              component,
-              includeAll,
-            );
-            set(data, childPath, childData);
-          }
         } else {
+          if (!includeAll && !shouldProcessComponent(component, row, value)) {
+            resetComponentScope(component);
+            return true;
+          }
           eachComponentData(
             component.components,
             data,
             fn,
-            componentDataPath(component, path, compPath),
-            index,
-            component,
             includeAll,
+            local,
+            component,
+            compPaths,
           );
         }
+        resetComponentScope(component);
         return true;
-      } else if (getModelType(component) === 'none') {
+      } else if (!component.type || getModelType(component) === 'none') {
         const info = componentInfo(component);
         if (info.hasColumns) {
-          const columnsComponent = component as HasColumns;
-          columnsComponent.columns.forEach((column: any) =>
-            eachComponentData(
-              column.components,
-              data,
-              fn,
-              componentFormPath(columnsComponent, path, columnsComponent.path),
-              index,
-              component,
-            ),
+          (component as HasColumns).columns.forEach((column: any) =>
+            eachComponentData(column.components, data, fn, includeAll, local, component, compPaths),
           );
         } else if (info.hasRows) {
-          const rowsComponent = component as HasRows;
-          rowsComponent.rows.forEach((row: any) => {
+          (component as HasRows).rows.forEach((row: any) => {
             if (Array.isArray(row)) {
               row.forEach((row) =>
                 eachComponentData(
                   row.components,
                   data,
                   fn,
-                  componentFormPath(rowsComponent, path, rowsComponent.path),
-                  index,
+                  includeAll,
+                  local,
                   component,
+                  compPaths,
                 ),
               );
             }
           });
         } else if (info.hasComps) {
-          const componentWithChildren = component as HasChildComponents;
           eachComponentData(
-            componentWithChildren.components,
+            (component as HasChildComponents).components,
             data,
             fn,
-            componentFormPath(componentWithChildren, path, componentWithChildren.path),
-            index,
+            includeAll,
+            local,
             component,
+            compPaths,
           );
         }
+        resetComponentScope(component);
         return true;
       }
+      resetComponentScope(component);
       return false;
     },
     true,
-    path,
+    parentPaths,
     parent,
   );
 };

--- a/src/utils/formUtil/eachComponentDataAsync.ts
+++ b/src/utils/formUtil/eachComponentDataAsync.ts
@@ -1,20 +1,21 @@
-import { get, set, isEmpty, has } from 'lodash';
+import { get } from 'lodash';
 
 import {
   Component,
   DataObject,
   EachComponentDataAsyncCallback,
-  HasChildComponents,
   HasColumns,
   HasRows,
+  ComponentPaths,
+  HasChildComponents,
 } from 'types';
 import {
-  getContextualRowData,
   isComponentNestedDataType,
-  getModelType,
-  componentDataPath,
   componentInfo,
-  componentFormPath,
+  getContextualRowData,
+  shouldProcessComponent,
+  resetComponentScope,
+  getModelType,
 } from './index';
 import { eachComponentAsync } from './eachComponentAsync';
 
@@ -23,116 +24,130 @@ export const eachComponentDataAsync = async (
   components: Component[],
   data: DataObject,
   fn: EachComponentDataAsyncCallback,
-  path = '',
-  index?: number,
-  parent?: Component,
   includeAll: boolean = false,
+  local: boolean = false,
+  parent?: Component,
+  parentPaths?: ComponentPaths,
 ) => {
   if (!components) {
     return;
   }
   return await eachComponentAsync(
     components,
-    async (component: any, compPath: string, componentComponents: any, compParent: any) => {
-      const row = getContextualRowData(component, compPath, data);
+    async (
+      component: Component,
+      compPath: string,
+      componentComponents: Component[] | undefined,
+      compParent: Component | undefined,
+      compPaths: ComponentPaths | undefined,
+    ) => {
+      const row = getContextualRowData(component, data, compPaths, local);
       if (
-        (await fn(component, data, row, compPath, componentComponents, index, compParent)) === true
+        (await fn(
+          component,
+          data,
+          row,
+          compPaths?.dataPath || '',
+          componentComponents,
+          compPaths?.dataIndex,
+          compParent,
+        )) === true
       ) {
+        resetComponentScope(component);
         return true;
       }
       if (isComponentNestedDataType(component)) {
-        const value = get(data, compPath, data);
-        if (Array.isArray(value)) {
-          for (let i = 0; i < value.length; i++) {
-            const nestedComponentPath =
-              getModelType(component) === 'nestedDataArray'
-                ? `${compPath}[${i}].data`
-                : `${compPath}[${i}]`;
-            await eachComponentDataAsync(
-              component.components,
-              data,
-              fn,
-              nestedComponentPath,
-              i,
-              component,
-              includeAll,
-            );
+        const value = get(data, local ? compPaths?.localDataPath || '' : compPaths?.dataPath || '');
+        if (
+          getModelType(component) === 'nestedArray' ||
+          getModelType(component) === 'nestedDataArray'
+        ) {
+          if (Array.isArray(value) && value.length) {
+            for (let i = 0; i < value.length; i++) {
+              if (compPaths) {
+                compPaths.dataIndex = i;
+              }
+              await eachComponentDataAsync(
+                component.components,
+                data,
+                fn,
+                includeAll,
+                local,
+                component,
+                compPaths,
+              );
+            }
           }
+          resetComponentScope(component);
           return true;
-        } else if (isEmpty(row) && !includeAll) {
-          // Tree components may submit empty objects; since we've already evaluated the parent tree/layout component, we won't worry about constituent elements
-          return true;
-        }
-        if (getModelType(component) === 'dataObject') {
-          const nestedFormValue: any = get(data, component.path);
-          const noReferenceAttached = nestedFormValue?._id
-            ? isEmpty(nestedFormValue.data) && !has(nestedFormValue, 'form')
-            : false;
-          const shouldBeCleared =
-            (!component.hasOwnProperty('clearOnHide') || component.clearOnHide) &&
-            (component.hidden || component.ephemeralState?.conditionallyHidden);
-          // Skip all the nested components processing if nested form is hidden and should be cleared on hide or if submission is saved as reference and not loaded
-          const shouldSkipProcessingNestedFormData = noReferenceAttached || shouldBeCleared;
-          if (!shouldSkipProcessingNestedFormData) {
-            // For nested forms, we need to reset the "data" and "path" objects for all of the children components, and then re-establish the data when it is done.
-            const childPath: string = componentDataPath(component, path, compPath);
-            const childData: any = get(data, childPath, null);
-            await eachComponentDataAsync(
-              component.components,
-              childData,
-              fn,
-              '',
-              index,
-              component,
-              includeAll,
-            );
-            set(data, childPath, childData);
-          }
         } else {
+          if (!includeAll && !shouldProcessComponent(component, row, value)) {
+            resetComponentScope(component);
+            return true;
+          }
           await eachComponentDataAsync(
             component.components,
             data,
             fn,
-            componentDataPath(component, path, compPath),
-            index,
-            component,
             includeAll,
+            local,
+            component,
+            compPaths,
           );
         }
+        resetComponentScope(component);
         return true;
-      } else if (getModelType(component) === 'none') {
+      } else if (!component.type || getModelType(component) === 'none') {
         const info = componentInfo(component);
         if (info.hasColumns) {
           const columnsComponent = component as HasColumns;
           for (const column of columnsComponent.columns) {
-            await eachComponentDataAsync(column.components, data, fn, path, index, component);
+            await eachComponentDataAsync(
+              column.components,
+              data,
+              fn,
+              includeAll,
+              local,
+              component,
+              compPaths,
+            );
           }
         } else if (info.hasRows) {
           const rowsComponent = component as HasRows;
           for (const rowArray of rowsComponent.rows) {
             if (Array.isArray(rowArray)) {
               for (const row of rowArray) {
-                await eachComponentDataAsync(row.components, data, fn, path, index, component);
+                await eachComponentDataAsync(
+                  row.components,
+                  data,
+                  fn,
+                  includeAll,
+                  local,
+                  component,
+                  compPaths,
+                );
               }
             }
           }
         } else if (info.hasComps) {
-          const componentWithChildren = component as HasChildComponents;
           await eachComponentDataAsync(
-            componentWithChildren.components,
+            (component as HasChildComponents).components,
             data,
             fn,
-            componentFormPath(componentWithChildren, path, componentWithChildren.path),
-            index,
+            includeAll,
+            local,
             component,
+            compPaths,
           );
         }
+        resetComponentScope(component);
         return true;
       }
+      resetComponentScope(component);
       return false;
     },
     true,
-    path,
+    parentPaths,
     parent,
   );
 };

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -558,10 +558,10 @@ export function getComponentLocalData(paths: ComponentPaths, data: any, local?: 
 }
 
 export function shouldProcessComponent(comp: Component, row: any, value: any): boolean {
-  if (isEmpty(row)) {
-    return false;
-  }
   if (getModelType(comp) === 'dataObject') {
+    if (isEmpty(row)) {
+      return false;
+    }
     const noReferenceAttached = value?._id ? isEmpty(value.data) && !has(value, 'form') : false;
     const shouldBeCleared =
       (!comp.hasOwnProperty('clearOnHide') || comp.clearOnHide) &&

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -17,8 +17,7 @@ import {
 } from 'types/AdvancedLogic';
 import { get, set, clone, isEqual, assign } from 'lodash';
 import { evaluate, interpolate } from 'modules/jsonlogic';
-import { registerEphemeralState } from './utils';
-import { getComponentAbsolutePath } from './formUtil';
+import { setComponentScope } from 'utils/formUtil';
 
 export const hasLogic = (context: LogicContext): boolean => {
   const { component } = context;
@@ -70,7 +69,6 @@ export function setActionBooleanProperty(
   action: LogicActionPropertyBoolean,
 ): boolean {
   const { component, scope, path } = context;
-  const absolutePath = getComponentAbsolutePath(component) || path;
   const property = action.property.value;
   const currentValue = get(component, property, false).toString();
   const newValue = action.state.toString();
@@ -79,19 +77,19 @@ export function setActionBooleanProperty(
 
     // If this is "logic" forcing a component to set hidden property, then we will set the "conditionallyHidden"
     // flag which will trigger the clearOnHide functionality.
-    if (property === 'hidden' && absolutePath) {
+    if (property === 'hidden' && path) {
       if (!(scope as ConditionsScope).conditionals) {
         (scope as ConditionsScope).conditionals = [];
       }
       const conditionallyHidden = (scope as ConditionsScope).conditionals?.find((cond: any) => {
-        return cond.path === absolutePath;
+        return cond.path === path;
       });
       if (conditionallyHidden) {
         conditionallyHidden.conditionallyHidden = !!component.hidden;
-        registerEphemeralState(component, 'conditionallyHidden', !!component.hidden);
+        setComponentScope(component, 'conditionallyHidden', !!component.hidden);
       } else {
         (scope as ConditionsScope).conditionals?.push({
-          path: absolutePath,
+          path,
           conditionallyHidden: !!component.hidden,
         });
       }

--- a/src/utils/operators/IsEqualTo.js
+++ b/src/utils/operators/IsEqualTo.js
@@ -3,7 +3,7 @@ import {
   isSelectResourceWithObjectValue,
 } from 'utils/formUtil';
 import ConditionOperator from './ConditionOperator';
-import { isString, isEqual, get } from 'lodash';
+import { isString, isEqual, get, isObject } from 'lodash';
 
 export default class IsEqualTo extends ConditionOperator {
   static get operatorKey() {
@@ -16,10 +16,9 @@ export default class IsEqualTo extends ConditionOperator {
 
   execute({ value, comparedValue, conditionComponent }) {
     // special check for select boxes
-    if (conditionComponent?.type === 'selectboxes') {
+    if (conditionComponent?.type === 'selectboxes' && isObject(value)) {
       return get(value, comparedValue, false);
     }
-
     if (
       value &&
       comparedValue &&

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,5 @@
 import { isBoolean, isString } from 'lodash';
-import { BaseComponent, Component, ResourceToDomOptions } from 'types';
+import { ResourceToDomOptions } from 'types';
 
 /**
  * Escapes RegEx characters in provided String value.
@@ -41,27 +41,6 @@ export function unescapeHTML(str: string) {
 
   const doc = new window.DOMParser().parseFromString(str, 'text/html');
   return doc.documentElement.textContent;
-}
-
-export function registerEphemeralState(
-  component: Component,
-  name: keyof NonNullable<BaseComponent['ephemeralState']>,
-  value: any,
-) {
-  if (!component.ephemeralState) {
-    Object.defineProperty(component, 'ephemeralState', {
-      enumerable: false,
-      configurable: true,
-      writable: true,
-      value: {},
-    });
-  }
-  Object.defineProperty(component.ephemeralState, name, {
-    enumerable: false,
-    writable: false,
-    configurable: true,
-    value,
-  });
 }
 
 export function attachResourceToDom(options: ResourceToDomOptions) {
@@ -119,10 +98,4 @@ export function attachResourceToDom(options: ResourceToDomOptions) {
       head.appendChild(element);
     }
   });
-}
-
-export function resetEphemeralState(component: Component) {
-  if (component.ephemeralState) {
-    delete component.ephemeralState;
-  }
 }


### PR DESCRIPTION
Before this change, the core library was trying to accomplish multiple "pathing" strategies using the single "path" variable passed through both the "eachComponent" as well as the "eachComponentData" methods. These paths were not following any strict rules on how they behaved causing MANY downstream issues with the renderer and data processing systems. This pull requests solves this issue by creating a very deterministic and structured pathing system when dealing with both the Form JSON as well as the Submission JSON objects.

To start, there are now 2 different "types" of paths.  Form paths and Data paths. They are defined as follows.

- Form Path: The path to a component within the Form JSON. This path is used to locate a component provided a nested Form JSON object.

- Data Path: The path to the data value of a component within the data model for the form. This path is used to provide the value path provided the Submission JSON object. 

These paths can also be broken into two different path "types".   Local and Full paths.

- Local Path: This is the path relative to the "current" form. This is used inside of a nested form to identify components and values relative to the current form in context.

- Full Path: This is the path that is absolute to the root form object. Any nested form paths will include the parent form path as part of the value for the provided path.

These definitions are used within the new "paths" construct which defines the following paths that describe a component.

- path: The "form" path to the component including all parent paths (exclusive of layout components). This path is used to uniquely identify component within a form inclusive of any parent form paths. For example, a form that has the following component structure (Panel => Form => Panel => Data Grid => Panel => Text Field) would have the following path:  **form.dataGrid.textField**
- fullPath: The "form" path to the component including all parent paths (inclusive of layout componnts). This path is used to uniquely identify component within a form inclusive of any parent form paths. For example, a form that has the following component structure (Panel => Form => Panel => Data Grid => Panel => Text Field) would have the following path:  **panel1.form.panel2.dataGrid.panel3.textField**
- localPath: The local "form" path to the component. This is the local path to any component within a form. This path is consistent no matter if this form is nested within another form or not. All form configurations are in relation to this path since forms are configured independently. The difference between a form path and a dataPath is that this includes any parent layout components to locate the component provided a form JSON. This path does NOT include any layout components. For example, a form that has the following component structure (Panel => Form => Panel => Data Grid => Panel => Text Field) would have the following path:  **dataGrid.textField**
- fullLocalPath: The local "form" path to the component. This is the local path to any component within a form. This path is consistent no matter if this form is nested within another form or not. All form configurations are in relation to this path since forms are configured independently. The difference between a form path and a dataPath is that this includes any parent layout components to locate the component provided a form JSON. This path does NOT include any layout components. For example, a form that has the following component structure (Panel => Form => Panel => Data Grid => Panel => Text Field) would have the following path:  **panel2.dataGrid.panel3.textField**
- dataPath: The "data" path to the component including all parent paths. This path is used to fetch the data value of a component within a data model, inclusive of any parent data paths of nested forms. For example, a form that has the following component structure (Panel => Form => Panel => Data Grid => Panel => Text Field) would have the following path:  **form.data.dataGrid[1].textField**
- localDataPath: The "data" path is the local path to the data value for any component. The difference between this path and the "path" is that this path is used to locate the data value for a component within the data model and does not include any keys for layout components. For example, a form that has the following component structure (Panel => Form => Panel => Data Grid => Panel => Text Field) would have the following path:  **dataGrid[1].textField**

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

This pull requests refactors the "eachComponentData" method to ensure that all of the paths described above are accounted for and can then be used for any component or data references throughout the SDK as well as the renderer.

## Breaking Changes / Backwards Compatibility

There are a few things that should be considered "breaking" with this PR.

1. eachComponent:  The callback function for eachComponent receives the "path" parameter as the second parameter to this callback function. This is now the "path" as defined above. 

For example.

```
eachComponent(form.components, function(component, path) {
  console.log(path);  // This is the "path" as defined above.
});
```

2. eachComponentData: The callback function for eachComponentData receives a "path" parameter for the third argument to that function. This is now the "dataPath" as defined above.

```
eachComponentData(form.components, data, function(component, row, path) {
  console.log(path);  // This is the "dataPath" as defined above.
});
```

3. "parent" is no longer assigned to the component. With this PR, we are no longer assigning the "parent" property to the component JSON. This is now passed through the iterators and can be referenced there.

## Dependencies

None

## How has this PR been tested?

New automated tests written.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
