### PR TITLE
FIO-8640: Fixes an issue where rowIndex is undefined in custom validation

### DIFF
--- a/src/process/validation/rules/validateCustom.ts
+++ b/src/process/validation/rules/validateCustom.ts
@@ -23,16 +23,17 @@ export const validateCustomSync: RuleFnSync = (context: ValidationContext) => {
       return null;
     }
 
+    const ctx = instance?.evalContext
+      ? instance.evalContext()
+      : evalContext
+        ? evalContext(context)
+        : context;
     const evalContextValue = {
-      ...(instance?.evalContext
-        ? instance.evalContext()
-        : evalContext
-          ? evalContext(context)
-          : context),
+      ...ctx,
       component,
       data,
       row,
-      rowIndex: index,
+      rowIndex: typeof index === 'number' ? index : ctx.rowIndex,
       instance,
       valid: true,
       input: value,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8640

## Description

The rowIndex in evelContext of custom validation was always overridden by context.index that is getting assigned only in a single place (when we have component set to multiple and process all its values at once instead of one by one) 

## Breaking Changes / Backwards Compatibility

_Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility_

## Dependencies

_Use this section to list any dependent changes/PRs in other Form.io modules_

## How has this PR been tested?

_Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning_

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
