### PR TITLE
FIO-9511: fixed day component min/max validation message

### DIFF
--- a/src/process/validation/rules/__tests__/validateMaximumDay.test.ts
+++ b/src/process/validation/rules/__tests__/validateMaximumDay.test.ts
@@ -24,7 +24,7 @@ describe('validateMaximumDay', function () {
     const context = generateProcessorContext(component, data);
     const result = await validateMaximumDay(context);
     expect(result).to.be.instanceOf(FieldError);
-    expect(result?.errorKeyOrMessage).to.equal('maxDay');
+    expect(result?.errorKeyOrMessage).to.equal('maxDate');
   });
 
   it('Validating a day component with a day before the maximum day will return null', async function () {
@@ -45,7 +45,7 @@ describe('validateMaximumDay', function () {
     const context = generateProcessorContext(component, data);
     const result = await validateMaximumDay(context);
     expect(result).to.be.instanceOf(FieldError);
-    expect(result?.errorKeyOrMessage).to.equal('maxDay');
+    expect(result?.errorKeyOrMessage).to.equal('maxDate');
   });
 
   it('Validating a day-first day component with a day before the maximum day will return null', async function () {

--- a/src/process/validation/rules/__tests__/validateMinimumDay.test.ts
+++ b/src/process/validation/rules/__tests__/validateMinimumDay.test.ts
@@ -24,7 +24,7 @@ describe('validateMinimumDay', function () {
     const context = generateProcessorContext(component, data);
     const result = await validateMinimumDay(context);
     expect(result).to.be.instanceOf(FieldError);
-    expect(result?.errorKeyOrMessage).to.equal('minDay');
+    expect(result?.errorKeyOrMessage).to.equal('minDate');
   });
 
   it('Validating a day component with a day after the minimum day will return null', async function () {
@@ -45,7 +45,7 @@ describe('validateMinimumDay', function () {
     const context = generateProcessorContext(component, data);
     const result = await validateMinimumDay(context);
     expect(result).to.be.instanceOf(FieldError);
-    expect(result?.errorKeyOrMessage).to.contain('minDay');
+    expect(result?.errorKeyOrMessage).to.contain('minDate');
   });
 
   it('Validating a day-first day component with a day after the minimum day will return null', async function () {

--- a/src/process/validation/rules/validateMaximumDay.ts
+++ b/src/process/validation/rules/validateMaximumDay.ts
@@ -1,6 +1,12 @@
 import { ProcessorError, FieldError } from 'error';
 import { DayComponent, RuleFn, RuleFnSync, ValidationContext } from 'types';
-import { dayjs, isPartialDay, getDateValidationFormat, getDateSetting } from 'utils/date';
+import {
+  dayjs,
+  isPartialDay,
+  getDateValidationFormat,
+  getDateSetting,
+  getDayFormat,
+} from 'utils/date';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 
 const isValidatableDayComponent = (component: any): component is DayComponent => {
@@ -47,9 +53,9 @@ export const validateMaximumDaySync: RuleFnSync = (context: ValidationContext) =
   } else {
     maxDate.setHours(0, 0, 0, 0);
   }
-  const error = new FieldError('maxDay', {
+  const error = new FieldError('maxDate', {
     ...context,
-    maxDate: String(maxDate),
+    maxDate: dayjs(maxDate).format(getDayFormat(component as DayComponent)),
     setting: String(maxDate),
   });
   return date.isBefore(dayjs(maxDate)) || date.isSame(dayjs(maxDate)) ? null : error;

--- a/src/process/validation/rules/validateMinimumDay.ts
+++ b/src/process/validation/rules/validateMinimumDay.ts
@@ -1,6 +1,12 @@
 import { ProcessorError, FieldError } from 'error';
 import { DayComponent, RuleFn, RuleFnSync, ValidationContext } from 'types';
-import { dayjs, isPartialDay, getDateValidationFormat, getDateSetting } from 'utils/date';
+import {
+  dayjs,
+  isPartialDay,
+  getDateValidationFormat,
+  getDateSetting,
+  getDayFormat,
+} from 'utils/date';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 
 const isValidatableDayComponent = (component: any): component is DayComponent => {
@@ -48,9 +54,9 @@ export const validateMinimumDaySync: RuleFnSync = (context: ValidationContext) =
   } else {
     minDate.setHours(0, 0, 0, 0);
   }
-  const error = new FieldError('minDay', {
+  const error = new FieldError('minDate', {
     ...context,
-    minDate: String(minDate),
+    minDate: dayjs(minDate).format(getDayFormat(component as DayComponent)),
     setting: String(minDate),
   });
   return date.isAfter(minDate) || date.isSame(minDate) ? null : error;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -3,7 +3,7 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import { isNaN, isNil } from 'lodash';
+import { isNaN, isNil, get } from 'lodash';
 import { Evaluator } from './Evaluator';
 import { DayComponent } from 'types';
 
@@ -80,6 +80,29 @@ export function formatDate(value: ConfigType, format: string, timezone?: string)
     return date.tz(timezone).format(`${dayjsFormat} z`);
   }
   return date.format(dayjsFormat);
+}
+
+export function getDayFormat(component: DayComponent) {
+  let format = '';
+  const showDay = !get(component, 'fields.day.hide', false);
+  const showMonth = !get(component, 'fields.month.hide', false);
+  const showYear = !get(component, 'fields.year.hide', false);
+  if (component.dayFirst && showDay) {
+    format += 'D/';
+  }
+  if (showMonth) {
+    format += 'M/';
+  }
+  if (!component.dayFirst && showDay) {
+    format += 'D/';
+  }
+  if (showYear) {
+    format += 'YYYY';
+    return format;
+  } else {
+    // Trim off the "/" from the end of the format string.
+    return format.length ? format.substring(0, format.length - 1) : format;
+  }
 }
 
 /**


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9511

## Description

**What changed?**

- fixed an issue where day min/max error message was not translated 
- fixed an issue where the min/max value displayed not in day format in error massage

## Dependencies


## How has this PR been tested?

Manually + tests

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
