### PR TITLE
FIO-8273 fixed advanced logic for data components

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -4965,6 +4965,112 @@ describe('Process Tests', function () {
     assert.deepEqual(context.data, submission.data);
   });
 
+  it('Should properly validate comopnents inside Data Components with Advanced logic', async () => {
+    const form = {
+      display: 'form',
+      components: [
+        {
+          label: 'Data Grid',
+          reorder: false,
+          addAnotherPosition: 'bottom',
+          layoutFixed: false,
+          enableRowGroups: false,
+          initEmpty: false,
+          tableView: false,
+          key: 'dataGrid',
+          type: 'datagrid',
+          input: true,
+          components: [
+            {
+              label: 'Text Field1',
+              tableView: true,
+              key: 'textField1',
+              logic: [
+                  {
+                    name: 'logic1',
+                    trigger: {
+                      type: 'javascript',
+                      javascript: 'result = !row.textField2;'
+                    },
+                    actions: [
+                      {
+                        name: 'action1',
+                        type: 'property',
+                        property: {
+                          label: 'Required',
+                          value: 'validate.required',
+                          type: 'boolean'
+                        },
+                        state: true
+                      }
+                    ]
+                  }
+              ],
+              type: 'textfield',
+              input: true
+            },
+            {
+              label: 'Text Field2',
+              tableView: true,
+              key: 'textField2',
+              logic: [
+                {
+                  name: 'logic2',
+                  trigger: {
+                    type: 'javascript',
+                    javascript: 'result = !row.textField1;'
+                  },
+                  actions: [
+                    {
+                      name: 'action2',
+                      type: 'property',
+                      property: {
+                        label: 'Required',
+                        value: 'validate.required',
+                        type: 'boolean'
+                      },
+                      state: true
+                    }
+                  ]
+                }
+              ],
+              type: 'textfield',
+              input: true
+            }
+          ]
+        }
+      ]
+    };
+    const submission ={
+      data: {
+        dataGrid: [
+          {
+            textField1: 'test',
+            textField2: ''
+          },
+          {
+            textField1: '',
+            textField2: 'test'
+          }
+        ]
+      }
+    }
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.evaluator,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    expect(context.components[0].components).to.deep.equal(form.components[0].components);
+    expect((context.scope as ValidationScope).errors).to.have.length(0);
+  });
+
   describe('Required component validation in nested form in DataGrid/EditGrid', function () {
     const nestedForm = {
       key: 'form',

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -4965,7 +4965,7 @@ describe('Process Tests', function () {
     assert.deepEqual(context.data, submission.data);
   });
 
-  it('Should properly validate comopnents inside Data Components with Advanced logic', async () => {
+  it('Should properly validate comopnents inside Data Components with Advanced logic', async function () {
     const form = {
       display: 'form',
       components: [

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -18,6 +18,7 @@ import {
 import { get, set, clone, isEqual, assign } from 'lodash';
 import { evaluate, interpolate } from 'modules/jsonlogic';
 import { setComponentScope } from 'utils/formUtil';
+import { fastCloneDeep } from "./fastCloneDeep";
 
 export const hasLogic = (context: LogicContext): boolean => {
   const { component } = context;
@@ -73,7 +74,13 @@ export function setActionBooleanProperty(
   const currentValue = get(component, property, false).toString();
   const newValue = action.state.toString();
   if (currentValue !== newValue) {
-    set(component, property, newValue === 'true');
+    if (property === 'hidden') {
+      set(component, 'hidden', newValue === 'true');
+    } else {
+      const newComponent = fastCloneDeep(component);
+      set(newComponent, property, newValue === 'true');
+      set(context, 'component', newComponent);
+    }
 
     // If this is "logic" forcing a component to set hidden property, then we will set the "conditionallyHidden"
     // flag which will trigger the clearOnHide functionality.


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8273

## Description

*Fixed the behavior when the properties of the original component changed when the logic was triggered, which led to a change in all nested components inside the Data components*
*Previously If the logic was triggered, then the properties of the original component changed. For example, there is a DataGrid component in the form. Inside the DataGrid component, there is a Text Field component with logic, when triggered, the required property for the textField component is added. For the DataGrid Component, the evaluate Process is executed row by row. Therefore, if validate.required = true is set in any row for TextField after triggering the logic, then this property changes the original component and is applied to all following TextField rows. This issue has been fixed by cloning the original component.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated tests have been added. All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
