### PR TITLE
FIO-9508: includeAll flag now works with nested components

### DIFF
--- a/src/process/calculation/index.ts
+++ b/src/process/calculation/index.ts
@@ -27,7 +27,7 @@ export const calculateProcessSync: ProcessorFnSync<CalculationScope> = (
   }
 
   const calculationContext = (scope as FetchScope).fetched
-    ? {...context, data: {...data, ...(scope as FetchScope).fetched}}
+    ? { ...context, data: { ...data, ...(scope as FetchScope).fetched } }
     : context;
   const evalContextValue = evalContext
     ? evalContext(normalizeContext(calculationContext))

--- a/src/utils/formUtil/__tests__/eachComponentData.test.ts
+++ b/src/utils/formUtil/__tests__/eachComponentData.test.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+
+import { eachComponentData } from '../eachComponentData';
+
+describe('eachComponentData', function () {
+  it('Should not iterate over each component in a nested component if includeAll=false and there is no data associated with the component', function () {
+    const components = [
+      {
+        type: 'datagrid',
+        key: 'dataGrid',
+        label: 'Data Grid',
+        input: true,
+        components: [
+          {
+            key: 'textField',
+            type: 'textfield',
+            label: 'Text Field',
+            input: true,
+          },
+        ],
+      },
+    ];
+
+    const data = {};
+
+    const rowResults: Map<string, any> = new Map();
+    eachComponentData(
+      components,
+      data,
+      (component, data, row, path) => {
+        rowResults.set(path, component.key);
+      },
+      false,
+    );
+    expect(rowResults.size).to.equal(1);
+    expect(rowResults.get('dataGrid')).to.deep.equal('dataGrid');
+  });
+
+  it('Should iterate over each component in a nested component if includeAll=true and there is no data associated with the component', function () {
+    const components = [
+      {
+        type: 'datagrid',
+        key: 'dataGrid',
+        label: 'Data Grid',
+        input: true,
+        components: [
+          {
+            key: 'textField',
+            type: 'textfield',
+            label: 'Text Field',
+            input: true,
+          },
+        ],
+      },
+    ];
+
+    const data = {};
+
+    const rowResults: Map<string, any> = new Map();
+    eachComponentData(
+      components,
+      data,
+      (component, data, row, path) => {
+        rowResults.set(path, component.key);
+      },
+      true,
+    );
+    expect(rowResults.size).to.equal(2);
+    expect(rowResults.get('dataGrid')).to.deep.equal('dataGrid');
+    expect(rowResults.get('dataGrid[0].textField')).to.deep.equal('textField');
+  });
+});

--- a/src/utils/formUtil/eachComponentData.ts
+++ b/src/utils/formUtil/eachComponentData.ts
@@ -83,6 +83,16 @@ export const eachComponentData = (
                 compPaths,
               );
             }
+          } else if (includeAll) {
+            eachComponentData(
+              component.components,
+              data,
+              fn,
+              includeAll,
+              local,
+              component,
+              compPaths,
+            );
           }
           resetComponentScope(component);
           return true;

--- a/src/utils/formUtil/eachComponentDataAsync.ts
+++ b/src/utils/formUtil/eachComponentDataAsync.ts
@@ -77,6 +77,16 @@ export const eachComponentDataAsync = async (
                 compPaths,
               );
             }
+          } else if (includeAll) {
+            await eachComponentDataAsync(
+              component.components,
+              data,
+              fn,
+              includeAll,
+              local,
+              component,
+              compPaths,
+            );
           }
           resetComponentScope(component);
           return true;

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -12,6 +12,7 @@ import {
   pad,
   isPlainObject,
   isArray,
+  isNumber,
   isEqual,
   isBoolean,
   omit,
@@ -333,6 +334,21 @@ export function getComponentPaths(
     localDataPath: componentPath(component, parent, parentPaths, ComponentPath.localDataPath),
     dataIndex: parentPaths?.dataIndex,
   };
+}
+
+export function getStringFromComponentPath(path: string | string[]) {
+  if (!isArray(path)) {
+    return path;
+  }
+  let strPath = '';
+  path.forEach((part, i) => {
+    if (isNumber(part)) {
+      strPath += `[${part}]`;
+    } else {
+      strPath += i === 0 ? part : `.${part}`;
+    }
+  });
+  return strPath;
 }
 
 export type ComponentMatch = {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9508

## Description

We [added an `includeAll` flag to the `eachComponentData` family of functions](https://github.com/formio/core/pull/84) to ensure that even when there is no submission data associated with a component you could opt in to iterating over it. However, this was not taking into account components nested in an e.g. data grid. This PR fixes that issue, commits a small formatting change, and adds an unrelated utility function for use in our other libraries.
 
## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Automated / manual testing

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
