### PR TITLE
FIO-9649: update componentMatches fn to not omit layout components; add tests

### DIFF
--- a/src/process/normalize/__tests__/normalize.test.ts
+++ b/src/process/normalize/__tests__/normalize.test.ts
@@ -366,33 +366,39 @@ describe('Normalize processor', function () {
         {
           label: 'Agree',
           value: 'agree',
-          tooltip: ''
-        }
+          tooltip: '',
+        },
       ],
       values: [
         {
           label: 'Yes',
           value: 'yes',
-          tooltip: ''
+          tooltip: '',
         },
         {
-          label: "No",
-          value: "no",
-          tooltip: ''
-        }
+          label: 'No',
+          value: 'no',
+          tooltip: '',
+        },
       ],
       validateWhenHidden: false,
       key: 'survey',
       type: 'survey',
-      input: true
+      input: true,
     };
-    const context1: ProcessorContext<ProcessorScope> = generateProcessorContext(surveyComponent, {survey: null});
+    const context1: ProcessorContext<ProcessorScope> = generateProcessorContext(surveyComponent, {
+      survey: null,
+    });
     normalizeProcessSync(context1);
     expect(context1.data).to.deep.equal({});
-    const context2: ProcessorContext<ProcessorScope> = generateProcessorContext(surveyComponent, {survey: 0});
+    const context2: ProcessorContext<ProcessorScope> = generateProcessorContext(surveyComponent, {
+      survey: 0,
+    });
     normalizeProcessSync(context2);
     expect(context2.data).to.deep.equal({});
-    const context3: ProcessorContext<ProcessorScope> = generateProcessorContext(surveyComponent, {survey: ''});
+    const context3: ProcessorContext<ProcessorScope> = generateProcessorContext(surveyComponent, {
+      survey: '',
+    });
     normalizeProcessSync(context3);
     expect(context3.data).to.deep.equal({});
   });

--- a/src/process/normalize/index.ts
+++ b/src/process/normalize/index.ts
@@ -45,7 +45,8 @@ const isTextFieldComponent = (component: any): component is TextFieldComponent =
 const isTimeComponent = (component: any): component is TimeComponent => component.type === 'time';
 const isNumberComponent = (component: any): component is NumberComponent =>
   component.type === 'number';
-const isSurveyComponent = (component: any): component is SurveyComponent => component.type === 'survey';
+const isSurveyComponent = (component: any): component is SurveyComponent =>
+  component.type === 'survey';
 
 const normalizeAddressComponentValue = (component: AddressComponent, value: any) => {
   if (!component.multiple && Boolean(component.enableManualMode) && value && !value.mode) {

--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -74,6 +74,32 @@ describe('formUtil', function () {
         expect(component?.key).to.equal(writtenNumber(n));
       }
     });
+
+    it('should get layout components using only their key', function () {
+      const form = {
+        display: 'form',
+        components: [
+          {
+            legend: 'Field Set',
+            key: 'fieldSet',
+            type: 'fieldset',
+            input: false,
+            components: [
+              {
+                type: 'panel',
+                key: 'myPanel',
+                input: false,
+                components: [],
+              },
+            ],
+          },
+        ],
+      };
+      const component = getComponent(form.components, 'myPanel');
+      expect(component, 'Component should be found');
+      expect(component!.key).to.equal('panel');
+      expect(component!.type).to.equal('panel');
+    });
   });
 
   describe('flattenComponents', function () {

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -439,7 +439,7 @@ export function componentMatches(
       }
     }
   });
-  if (!matches.key && component.input !== false && component.key === path) {
+  if (!matches.key && component.key === path) {
     matches.key = addMatch('key', { component, paths });
   }
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9649

## Description

Previously, I could call `getComponent('keyToLayoutComponent'` from a nested component instance (e.g. [in the Developer Portal application's resourcefields component shim](https://github.com/formio/formio-app/blob/e0dbcf759a1f6426bb506ce66ef46e53acde9051/src/scripts/module/resourcefields.js#L92), which calls that function to get a Panel component). However, with the introduction of the new pathing regime, this broke because we omit layout components by checking the component JSON for the `input` property.

This PR updates that change to allow for layout components to be retrieved using `getComponent` using just their key.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Automated test added

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
