### PR TITLE
FIO-9668: Fix custom error messages are not highlighted

### DIFF
--- a/src/error/FieldError.ts
+++ b/src/error/FieldError.ts
@@ -39,13 +39,13 @@ export class FieldError {
       level = 'error',
     } = context;
     this.ruleName = ruleName;
+    this.level = level;
     if (context.component.validate?.customMessage) {
       this.errorKeyOrMessage = context.component.validate.customMessage;
       this.context = { ...context, hasLabel: false, field, level };
     } else {
       this.errorKeyOrMessage = errorKeyOrMessage;
       this.context = { ...context, hasLabel, field };
-      this.level = level;
     }
   }
 }

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -5875,5 +5875,47 @@ describe('Process Tests', function () {
       processSync(context);
       expect(context.data).to.deep.equal({ selector: false, container: { textField: 'test' } });
     });
+
+    it("Should save 'level' field when custom error message is defined to correctly add error classes into app template ", async function () {
+      const components = [
+        {
+          label: "Text Field",
+          applyMaskOn: "change",
+          tableView: true,
+          validate: {
+            required: true,
+            customMessage: "mikhail"
+          },
+          validateWhenHidden: false,
+          key: "textField",
+          type: "textfield",
+          input: true
+        },
+        {
+          label: "Submit",
+          showValidations: false,
+          tableView: false,
+          key: "submit",
+          type: "button",
+          input: true,
+          saveOnEnter: false
+        }
+      ];
+      const submission = {
+        data: {
+          textField: "",
+          submit: true
+        }
+      }
+      const context = {
+        submission,
+        data: submission.data,
+        components,
+        processors: ProcessTargets.evaluator,
+        scope: {} as { errors: Record<string,unknown>[] }
+      };
+      processSync(context);
+      expect(context.scope.errors[0].level).to.equal("error");
+    });
   });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9668

## Description

**What changed?**

I've added "level" field to be assigned to custom errors, since it's needed in formio.js, as it filters out all non-"error" level messages.

**Why have you chosen this solution?**

Our other errors (required, min, max, etc.) already have that "level" assigned and work fine.

## Breaking Changes / Backwards Compatibility

_Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility_

## Dependencies

_Use this section to list any dependent changes/PRs in other Form.io modules_

## How has this PR been tested?

I've added an automated test case.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
