### PR TITLE
Hotfix/fix type aliases

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -4,11 +4,11 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 module.exports = {
   mode: 'development',
   entry: {
-    'formio.core.js': './src/index.ts',
-    'formio.modules.js': './src/modules/index.ts',
-    'formio.js': './src/sdk/index.ts',
-    'formio.utils.js': './src/utils/index.ts',
-    'formio.process.js': './src/process/index.ts',
+    'formio.core.js': './lib/index.js',
+    'formio.modules.js': './lib/modules/index.js',
+    'formio.js': './lib/sdk/index.js',
+    'formio.utils.js': './lib/utils/index.js',
+    'formio.process.js': './lib/process/index.js',
   },
   output: {
     library: {
@@ -28,20 +28,6 @@ module.exports = {
     }),
   ],
   resolve: {
-    extensions: ['.ts', '.js'],
-    plugins: [
-      new TsconfigPathsPlugin({
-        configFile: path.resolve(__dirname, '..', 'tsconfig.json'),
-      }),
-    ],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        exclude: /\.spec\.ts$/,
-        loader: 'ts-loader',
-      },
-    ],
+    extensions: ['.js'],
   },
 };

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -1,10 +1,9 @@
-const path = require('path');
 const config = require('./webpack.config');
 config.mode = 'production';
 config.entry = {
-  'formio.core.min.js': './src/index.ts',
-  'formio.modules.min.js': './src/modules/index.ts',
-  'formio.min.js': './src/sdk/index.ts',
-  'formio.utils.min.js': './src/utils/index.ts',
+  'formio.core.min.js': './lib/index.js',
+  'formio.modules.min.js': './lib/modules/index.js',
+  'formio.min.js': './lib/sdk/index.js',
+  'formio.utils.min.js': './lib/utils/index.js',
 };
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "test": "TEST=1 nyc --reporter=lcov --reporter=text --reporter=text-summary mocha -b -r ts-node/register -r tsconfig-paths/register -r mock-local-storage -r jsdom-global/register -t 0 'src/**/__tests__/*.test.ts'",
-    "lib": "tsc --project tsconfig.json && tsc-alias -p tsconfig.json",
+    "lib": "tsc --project tsconfig.json",
+    "alias": "tsc-alias -p tsconfig.json",
     "lib:watch": "tsc -w & tsc-alias -w",
     "replace": "node -r tsconfig-paths/register -r ts-node/register ./lib/base/array/ArrayComponent.js",
     "test:debug": "mocha -r ts-node/register -r tsconfig-paths/register -r mock-local-storage -r jsdom-global/register --debug-brk --inspect '**/*.spec.ts'",
@@ -23,7 +24,7 @@
     "build:dev": "npx webpack --config config/webpack.config.js",
     "build:prod": "npx webpack --config config/webpack.prod.js",
     "clean": "rm -rf lib && rm -rf dist && rm -rf docs",
-    "build": "yarn clean && gulp templates && yarn docs && yarn lib && yarn build:dev && yarn build:prod",
+    "build": "yarn clean && gulp templates && yarn docs && yarn lib && yarn alias && yarn build:dev && yarn build:prod",
     "prepublish": "yarn lint && yarn format && yarn build && yarn test",
     "show-coverage": "open coverage/lcov-report/index.html",
     "lint": "eslint src",


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

Webpack was clobbering the type de-aliasing (`tsc-alias`) by directly transpiling typescript. Now webpack uses the already transpiled `lib` directory, and the `tsc-alias` can do its job unperturbed by a downstream webpack process.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
