### PR TITLE
FIO-9642: enhance error information

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:prod": "npx webpack --config config/webpack.prod.js",
     "clean": "rm -rf lib && rm -rf dist && rm -rf docs",
     "build": "yarn clean && gulp templates && yarn docs && yarn lib && yarn alias && yarn build:dev && yarn build:prod",
-    "prepublish": "yarn lint && yarn format && yarn build && yarn test",
+    "prepublishOnly": "yarn lint && yarn format && yarn build && yarn test",
     "show-coverage": "open coverage/lcov-report/index.html",
     "lint": "eslint src",
     "format": "prettier --write .",

--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -1617,7 +1617,7 @@ export class Formio {
             response.headers.get('content-type').includes('application/json')
               ? response.json()
               : response.text()
-          ).then((error: any) => {
+          ).then((error: object | string) => {
             return Promise.reject({ ...response, error });
           });
         }

--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -1618,7 +1618,7 @@ export class Formio {
               ? response.json()
               : response.text()
           ).then((error: any) => {
-            return Promise.reject(error);
+            return Promise.reject({ ...response, error });
           });
         }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9642

## Description

**What changed?**

Included response information in the error
Tech debt: changed prepublish -> prepublishOnly

**Why have you chosen this solution?**

Allows for better error handling by customers. Sometimes they want to handle errors based on status codes, urls, etc. Adding the response body allows them to do this

## Breaking Changes / Backwards Compatibility

The error will no longer just be text or json. It will now be an object and the error that was returned previously will now be in a property called error in the object

## Dependencies

N/A

## How has this PR been tested?

Manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
