### PR TITLE
FIO-9796: Fixed issue where the conditions from a previous run may be in the wrong state for conditionally hidden.

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -5112,6 +5112,76 @@ describe('Process Tests', function () {
         expect((context.scope as ValidationScope).errors).to.have.length(0);
       });
 
+      it('Should not clear a value when it uses simple conditionals to hide and dependent value uses calculated value.', async function () {
+        const components: any = [
+          {
+            label: 'Checkbox',
+            tableView: false,
+            calculateValue: 'value = true;',
+            calculateServer: true,
+            validateWhenHidden: false,
+            key: 'checkbox',
+            type: 'checkbox',
+            input: true,
+            defaultValue: false,
+          },
+          {
+            label: 'Radio',
+            optionsLabelPosition: 'right',
+            inline: false,
+            tableView: false,
+            values: [
+              {
+                label: 'yes',
+                value: 'yes',
+                shortcut: '',
+              },
+              {
+                label: 'no',
+                value: 'no',
+                shortcut: '',
+              },
+            ],
+            validateWhenHidden: false,
+            conditional: {
+              show: true,
+              conjunction: 'all',
+              conditions: [
+                {
+                  component: 'checkbox',
+                  operator: 'isEqual',
+                  value: true,
+                },
+              ],
+            },
+            key: 'radio',
+            type: 'radio',
+            input: true,
+          },
+        ];
+        const submission = {
+          data: {
+            radio: 'yes',
+          },
+        };
+
+        const context = {
+          form: { components },
+          submission,
+          data: submission.data,
+          components,
+          processors: ProcessTargets.submission,
+          scope: {},
+          config: {
+            server: true,
+          },
+        };
+        processSync(context);
+        context.processors = ProcessTargets.evaluator;
+        processSync(context);
+        assert.equal(context.data.radio, 'yes');
+      });
+
       it('Should not validate required component when it is not filled out', async function () {
         const submission = {
           data: {

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -102,8 +102,7 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
     scope.conditionals.push(conditionalComp);
   }
 
-  conditionalComp.conditionallyHidden =
-    conditionalComp.conditionallyHidden || isHidden(context) === true;
+  conditionalComp.conditionallyHidden = isHidden(context) === true;
   if (conditionalComp.conditionallyHidden) {
     setComponentScope(component, 'conditionallyHidden', true);
   }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9796

## Description

There is an issue where if you have simple conditionals dependent on a calculated value state, the state of "conditionallyHidden" gets set and never gets updated with the correct state. This change ensures that the state is always re-calculated when the processors are re-evaluated.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Automated tests written

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
