### PR TITLE
FIO-9737: add deprecated tag to the unwind method

### DIFF
--- a/src/utils/unwind.ts
+++ b/src/utils/unwind.ts
@@ -39,6 +39,9 @@ export function rewind(submissions: any) {
   return submission;
 }
 
+/**
+ * @deprecated This method is no longer supported
+ */
 export function unwind(form: any, submission: any) {
   const dataPaths = {};
   const locked = {};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9737

## Description

Adds the deprecated tag to the `unwind` utility method. See [pdf-server#428](https://github.com/formio/pdf-server/pull/428) for details.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
