### PR TITLE
FIO-9776: Excluded Address2 field from required validation

### DIFF
--- a/src/process/validation/rules/__tests__/fixtures/components.ts
+++ b/src/process/validation/rules/__tests__/fixtures/components.ts
@@ -242,3 +242,67 @@ export const requiredNonInputField: any = {
     required: true,
   },
 };
+
+export const requiredAddressManualMode: any = {
+  label: 'Address',
+  enableManualMode: true,
+  provider: 'nominatim',
+  validate: {
+    required: true,
+  },
+  key: 'component',
+  type: 'address',
+  providerOptions: {
+    params: {},
+  },
+  input: true,
+  components: [
+    {
+      label: 'Address 1',
+      key: 'address1',
+      type: 'textfield',
+      input: true,
+      customConditional: "show = _.get(instance, 'parent.manualMode', false);",
+    },
+    {
+      label: 'Address 2',
+      tableView: false,
+      key: 'address2',
+      type: 'textfield',
+      input: true,
+      customConditional: "show = _.get(instance, 'parent.manualMode', false);",
+    },
+    {
+      label: 'City',
+      tableView: false,
+      key: 'city',
+      type: 'textfield',
+      input: true,
+      customConditional: "show = _.get(instance, 'parent.manualMode', false);",
+    },
+    {
+      label: 'State',
+      tableView: false,
+      key: 'state',
+      type: 'textfield',
+      input: true,
+      customConditional: "show = _.get(instance, 'parent.manualMode', false);",
+    },
+    {
+      label: 'Country',
+      tableView: false,
+      key: 'country',
+      type: 'textfield',
+      input: true,
+      customConditional: "show = _.get(instance, 'parent.manualMode', false);",
+    },
+    {
+      label: 'Zip Code',
+      tableView: false,
+      key: 'zip',
+      type: 'textfield',
+      input: true,
+      customConditional: "show = _.get(instance, 'parent.manualMode', false);",
+    },
+  ],
+};

--- a/src/process/validation/rules/__tests__/validateRequired.test.ts
+++ b/src/process/validation/rules/__tests__/validateRequired.test.ts
@@ -10,6 +10,7 @@ import {
   simpleSelectBoxes,
   simpleRadioField,
   simpleCheckBoxField,
+  requiredAddressManualMode,
 } from './fixtures/components';
 import { processOne } from 'processes/processOne';
 import { generateProcessorContext } from './fixtures/util';
@@ -231,5 +232,25 @@ describe('validateRequired', function () {
     const context = generateProcessorContext(component, data);
     const result = await validateRequired(context);
     expect(result).to.be.instanceOf(FieldError);
+  });
+
+  it('Should not return error message for empty Address 2 field in Address Component with manual mode', async function () {
+    const component = { ...requiredAddressManualMode };
+    const data = {
+      component: {
+        mode: 'manual',
+        address: {
+          address1: '2140 Worthington Drive',
+          address2: '',
+          city: 'Plano',
+          country: 'US',
+          state: 'Texas',
+          zip: '75074',
+        },
+      },
+    };
+    const context = generateProcessorContext(component, data);
+    const result = await validateRequired(context);
+    expect(result).to.equal(null);
   });
 });

--- a/src/process/validation/rules/validateRequired.ts
+++ b/src/process/validation/rules/validateRequired.ts
@@ -89,7 +89,9 @@ export const validateRequiredSync: RuleFnSync = (context: ValidationContext) => 
   if (isAddressComponent(component) && isAddressComponentDataObject(value)) {
     return isEmptyObject(value.address)
       ? error
-      : Object.values(value.address).every((val) => !!val)
+      : Object.entries(value.address)
+            .filter(([key]) => !['address2'].includes(key))
+            .every(([, val]) => !!val)
         ? null
         : error;
   } else if (isDayComponent(component) && value === '00/00/0000') {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9776

## Description

**Issue**: Every value in the object of the manual mode of the address component should have a value to pass the required validation.
**Solution**: Added a filter to exclude the Address2 field from the required validation.

## How has this PR been tested?

Unit testing.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
