### PR TITLE
FIO-9908: fixed an issue where conditional setting with "show" set as a string does not work well

### DIFF
--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -1570,6 +1570,30 @@ describe('formUtil', function () {
       const result = hasCondition(component as Component);
       expect(result).to.equal(false);
     });
+
+    it('Should return true if the simple condition "show" value is a string', function () {
+      const component = {
+        label: 'Text Field',
+        hidden: false,
+        key: 'textField',
+        conditional: {
+          show: 'true',
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'checkbox',
+              operator: 'isEqual',
+              value: true,
+            },
+          ],
+        },
+        type: 'textfield',
+        input: true,
+      };
+
+      const result = hasCondition(component as any);
+      expect(result).to.equal(true);
+    });
   });
 
   describe('getModelType', function () {

--- a/src/utils/conditions.ts
+++ b/src/utils/conditions.ts
@@ -1,7 +1,7 @@
 import { ConditionsContext, JSONConditional, LegacyConditional, SimpleConditional } from 'types';
 import { EvaluatorFn, evaluate, JSONLogicEvaluator } from 'modules/jsonlogic';
 import { getComponent, getComponentValue, normalizeContext } from './formUtil';
-import { has, isObject, map, every, some, find, filter } from 'lodash';
+import { has, isObject, map, every, some, find, filter, isString } from 'lodash';
 import ConditionOperators from './operators';
 
 export const isJSONConditional = (conditional: any): conditional is JSONConditional => {
@@ -101,6 +101,25 @@ export function checkJsonConditional(
 }
 
 /**
+ * Convert the 'show' property of simple conditional to boolean
+ * @param show
+ * @returns {boolean}
+ */
+export function convertShowToBoolean(show: any) {
+  let shouldShow = show;
+  if (isString(show)) {
+    try {
+      shouldShow = JSON.parse(show);
+    } catch (e) {
+      console.log(e);
+      shouldShow = show;
+    }
+  }
+
+  return !!shouldShow;
+}
+
+/**
  * Checks the simple conditionals.
  * @param conditional
  * @param context
@@ -161,5 +180,5 @@ export function checkSimpleConditional(
     default:
       result = every(conditionsResult, (res) => !!res);
   }
-  return show ? result : !result;
+  return convertShowToBoolean(show) ? result : !result;
 }

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -762,7 +762,8 @@ export function hasCondition(component: Component) {
         ((component.conditional as LegacyConditional).when ||
           (component.conditional as JSONConditional).json ||
           ((component.conditional as SimpleConditional).conjunction &&
-            isBoolean((component.conditional as SimpleConditional).show) &&
+            (isBoolean((component.conditional as SimpleConditional).show) ||
+              (component.conditional as SimpleConditional).show) &&
             !isEmpty((component.conditional as SimpleConditional).conditions)))),
   );
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './date';
 export * from './mask';
 export * from './fastCloneDeep';
 export * from './Database';
+export * from './conditions';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9908

## Description

**What changed?**

If the conditional 'show' is a string (like 'true' or 'false'), we need to parse it and convert to boolean so that it works as expected.

## Dependencies

https://github.com/formio/premium/pull/386
https://github.com/formio/formio.js/pull/6069

## How has this PR been tested?

Manually + autotests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
