### PR TITLE
FIO-9874: fixed an issue where operands disappear

### DIFF
--- a/src/process/process.ts
+++ b/src/process/process.ts
@@ -44,7 +44,9 @@ export async function process<ProcessScope>(
         paths,
         row,
         index,
-        instance: instances ? instances[path] : undefined,
+        instance: instances
+          ? instances[component.modelType === 'none' && paths?.fullPath ? paths.fullPath : path]
+          : undefined,
         parent,
       });
       if (flat) {
@@ -85,7 +87,9 @@ export function processSync<ProcessScope>(context: ProcessContext<ProcessScope>)
         paths,
         row,
         index,
-        instance: instances ? instances[path] : undefined,
+        instance: instances
+          ? instances[component.modelType === 'none' && paths?.fullPath ? paths.fullPath : path]
+          : undefined,
         parent,
       });
       if (flat) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9874

## Description

The issue were caused by using wrong instance. Disappearing operands are nested inside columns component that has `modelType = 'none'`, having two columns component within the form caused path collision. Added condition to use fullpath (that is unique) to set the exact instance.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

tested manually, all existing tests pass locally
## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
