### PR TITLE
2.3.x: FIO-9964: fixed an issue where getComponent returns wrong component when the form includes several components with the same key

### DIFF
--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -74,6 +74,122 @@ describe('formUtil', function () {
         expect(component?.key).to.equal(writtenNumber(n));
       }
     });
+
+    it('Should return correct component when the form has 2 components with the same key', function () {
+      const component = getComponent(
+        [
+          {
+            label: 'Tabs',
+            components: [
+              {
+                label: 'Tab1',
+                key: 'tab1',
+                components: [
+                  {
+                    label: 'Text Field',
+                    tableView: true,
+                    validateWhenHidden: false,
+                    key: 'someDuplicatedKey',
+                    type: 'textfield',
+                    input: true,
+                  },
+                ],
+              },
+              {
+                label: 'Tab2',
+                key: 'tab2',
+                components: [
+                  {
+                    label: 'Another container',
+                    tableView: false,
+                    key: 'anotherContainerKey',
+                    type: 'container',
+                    input: true,
+                    components: [
+                      {
+                        label:
+                          "A select with the same key of a container in tab1. Select the option 'more'",
+                        widget: 'choicesjs',
+                        tableView: true,
+                        data: {
+                          values: [
+                            {
+                              label: 'less',
+                              value: 'less',
+                            },
+                            {
+                              label: 'more',
+                              value: 'more',
+                            },
+                          ],
+                        },
+                        validateWhenHidden: false,
+                        key: 'someDuplicatedKey',
+                        type: 'select',
+                        input: true,
+                      },
+                      {
+                        label: 'Here select yes, value will disappear',
+                        tableView: false,
+                        validateWhenHidden: false,
+                        key: 'additionalContainer',
+                        conditional: {
+                          show: true,
+                          conjunction: 'all',
+                          conditions: [
+                            {
+                              component: 'someDuplicatedKey',
+                              operator: 'isEqual',
+                              value: 'more',
+                            },
+                          ],
+                        },
+                        type: 'container',
+                        input: true,
+                        components: [
+                          {
+                            label: 'Select yes here, the value will disappear upon save',
+                            labelPosition: 'left-left',
+                            optionsLabelPosition: 'right',
+                            inline: true,
+                            tableView: false,
+                            values: [
+                              {
+                                label: 'yes',
+                                value: 'yes',
+                                shortcut: '',
+                              },
+                              {
+                                label: 'no',
+                                value: 'no',
+                                shortcut: '',
+                              },
+                            ],
+                            validateWhenHidden: false,
+                            key: 'aradiobutton',
+                            type: 'radio',
+                            input: true,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            key: 'tabs',
+            type: 'tabs',
+            input: false,
+            tableView: false,
+          },
+        ],
+        'someDuplicatedKey',
+      );
+      expect(component).not.to.equal(null);
+      expect(component).not.to.equal(undefined);
+      expect(component).to.be.an('object');
+      expect((component as any).type).to.equal('textfield');
+    });
   });
 
   describe('flattenComponents', function () {

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -421,11 +421,11 @@ export function getComponent(
   key: any,
   includeAll: any = false,
 ): Component | undefined {
-  let result;
+  let result: Component | undefined;
   eachComponent(
     components,
     (component: Component, path: any) => {
-      if (path === key || (component.input && component.key === key)) {
+      if ((path === key || (component.input && component.key === key)) && !result) {
         result = component;
         return true;
       }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9964

## Description

**What changed?**

When the form has several components with the same key (e.g. components with paths 'repeatedKey' and 'container.repeatedKey'), and you try to get the component using the key 'repeatedKey', the getComponent always returns the component with this key that goes the last in the eachComponent iteration, that is the component with path 'container.repeatedKey'. So, there is no way to get the 'repeatedKey'  component. This PR made it so that getComponent returns the component that matches first within the eachComponent iteration. If someone needs to get the 'container.repeatedKey' component, instead of the key, the path should be passed to getComponent.

This fix is for 2.3.x only.
The getComponent in formio/js@4.x works fine because it did not make the key comparison. 
The getComponent in core master and core@2.4.x works fine because those branches have far more changes in pathing/hidden logic and the getComponent is totally refactored.

## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
