### PR TITLE
FIO-9942: Fix issue with disabling evaluations

### DIFF
--- a/src/utils/Evaluator.ts
+++ b/src/utils/Evaluator.ts
@@ -18,7 +18,16 @@ export class BaseEvaluator {
     evaluate: /\{%([\s\S]+?)%\}/g,
     escape: /\{\{\{([\s\S]+?)\}\}\}/g,
   };
-  public static noeval: boolean = false;
+  private static _noeval = false;
+
+  public static get noeval(): boolean {
+    return BaseEvaluator._noeval;
+  }
+
+  public static set noeval(value: boolean) {
+    BaseEvaluator._noeval = value;
+  }
+
   public static evaluator(func: any, ...params: any) {
     if (Evaluator.noeval) {
       console.warn('No evaluations allowed for this renderer.');

--- a/src/utils/__tests__/Evaluator.test.ts
+++ b/src/utils/__tests__/Evaluator.test.ts
@@ -1,5 +1,6 @@
 import { Evaluator } from '../Evaluator';
 import { assert } from 'chai';
+import { noop } from 'lodash';
 
 describe('Evaluator', function () {
   it('Should be able to interpolate a string with Evaluator', function () {
@@ -226,6 +227,28 @@ describe('Evaluator', function () {
         getUTCDate: (date: string) => new Date(date).toUTCString(),
       }),
       '<span>Sun, 02 May 2021 21:00:00 GMT</span>',
+    );
+  });
+
+  it('Should enable or disable evaluation based on the noeval option', function () {
+    Evaluator.noeval = true;
+    assert.equal(
+      Evaluator.evaluator(`<span>{{ data.firstName }}</span>`, {
+        data: {
+          firstName: 'Travis',
+        },
+      }),
+      noop,
+    );
+
+    Evaluator.noeval = false;
+    assert.equal(
+      Evaluator.interpolate(`<span>{{data.firstName }}</span>`, {
+        data: {
+          firstName: 'Travis',
+        },
+      }),
+      '<span>Travis</span>',
     );
   });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9942

## Description

Refactored the static noeval flag across BaseEvaluator, Evaluator, and JSONLogicEvaluator classes to ensure consistency. Introduced a getter and setter for noeval in BaseEvaluator to centralize its value and make it shared across all evaluator layers. 
Previously, each evaluator class had its own separate static noeval property, which caused inconsistencies when toggling evaluation behavior. 

## Breaking Changes / Backwards Compatibility
-

## Dependencies
-

## How has this PR been tested?
manually
autotests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
