### PR TITLE
FIO-9942: use 'this' instead of 'Evaluator' for inheritance support

### DIFF
--- a/src/utils/Evaluator.ts
+++ b/src/utils/Evaluator.ts
@@ -198,7 +198,7 @@ export class Evaluator extends BaseEvaluator {
    */
   public static registerEvaluator(evaluator: any) {
     Object.keys(evaluator).forEach((key) => {
-      (Evaluator as any)[key] = evaluator[key];
+      (this as any)[key] = evaluator[key];
     });
   }
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9942

## Description

Added a static registerEvaluator method to work properly with extended evaluator classes by using this instead of referencing the base Evaluator class directly.
This ensures that any subclass extending the Evaluator can successfully register additional methods or properties using registerEvaluator.

## Dependencies
-

## How has this PR been tested?
manually  during the process of connecting @formio/protected-eval to 5.x renderer.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
