### PR TITLE
FIO-9683 fixed extra validation message for file component

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -5169,6 +5169,54 @@ describe('Process Tests', function () {
     assert.deepEqual(context.data, submission.data);
   });
 
+  it('Should return only a single require error message for File component with Multiple Values and require', async function () {
+    const form = {
+      components: [
+        {
+          label: 'Upload',
+          tableView: false,
+          storage: 'base64',
+          webcam: false,
+          capture: false,
+          fileTypes: [
+            {
+              label: '',
+              value: '',
+            },
+          ],
+          multiple: true,
+          validate: {
+            required: true,
+          },
+          validateWhenHidden: false,
+          key: 'file',
+          type: 'file',
+          input: true,
+        },
+      ],
+    };
+
+    const submission = {
+      data: {
+        file: [],
+      },
+    };
+
+    const errors: any = [];
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.evaluator,
+      scope: { errors },
+      config: {},
+    };
+    processSync(context);
+    expect((context.scope as ValidationScope).errors).to.have.length(1);
+    assert.equal(context.scope.errors[0].ruleName, 'required');
+  });
+
   describe('Required component validation in nested form in DataGrid/EditGrid', function () {
     const nestedForm = {
       key: 'form',

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -7,6 +7,7 @@ import {
   TagsComponent,
   RuleFnSync,
   ValidationContext,
+  FileComponent,
 } from 'types';
 import { ProcessorInfo } from 'types/process/ProcessorInfo';
 import { getModelType } from 'utils/formUtil';
@@ -40,6 +41,10 @@ export const isEligible = (component: Component) => {
 
 const isTagsComponent = (component: any): component is TagsComponent => {
   return component?.type === 'tags';
+};
+
+const isFileComponent = (component: any): component is FileComponent => {
+  return component?.type === 'file';
 };
 
 export const emptyValueIsArray = (component: Component) => {
@@ -103,7 +108,9 @@ export const validateMultipleSync: RuleFnSync = (context: ValidationContext) => 
       return null;
     } else if (valueIsArray && !underlyingValueShouldBeArray) {
       if (value.length === 0) {
-        return isRequired ? new FieldError('array_nonempty', { ...context, setting: true }) : null;
+        return isRequired && !isFileComponent(component)
+          ? new FieldError('array_nonempty', { ...context, setting: true })
+          : null;
       }
 
       return Array.isArray(value[0]) && compModelType !== 'any'


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9683

## Description

*Previously, when validating an empty component file with the Multiple Values property set and the required validation, two errors appeared. Since the value for the file component is always an array, for both single and multiple values, the validateRequired process checks for data for the value of the File component and returns the required error if the value is empty. Therefore, in the validate Multiple process, provided that the component file has the validate.required, the error of a non-empty array should not appear.*

## Breaking Changes / Backwards Compatibility

_n/a_

## Dependencies

_n/a_

## How has this PR been tested?

*Automated tests was added. All tests pass locally.*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
