### PR TITLE
FIO-10099: fix an issue where conditionally hidden layout components that are children of containers can wreak havoc

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -4861,6 +4861,156 @@ describe('Process Tests', function () {
     expect((scope as ValidationScope).errors).to.have.length(3);
   });
 
+  it('Should not clear container components when they have child layout components', function () {
+    // This form has a parent container with some layout children each containing a text field
+    // The issue was that the path was not being correctly evaluated - since the layout component contains the conditional, we were trying to get its
+    // path (something like `container.panel`) but instead received `container`, which led to the container being cleared because clearOnHide is
+    // enabled by default
+    const form = {
+      components: [
+        {
+          label: 'Checkbox',
+          tableView: false,
+          validateWhenHidden: false,
+          key: 'checkbox',
+          type: 'checkbox',
+          input: true,
+        },
+        {
+          label: 'Container',
+          tableView: false,
+          validateWhenHidden: false,
+          key: 'container',
+          type: 'container',
+          input: true,
+          components: [
+            {
+              label: 'Panel',
+              collapsible: false,
+              key: 'panel',
+              type: 'panel',
+              input: false,
+              tableView: false,
+              components: [
+                {
+                  label: 'Text Field',
+                  applyMaskOn: 'change',
+                  tableView: true,
+                  validateWhenHidden: false,
+                  key: 'textField',
+                  type: 'textfield',
+                  input: true,
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel1',
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField1',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel2',
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField2',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel3',
+                  conditional: {
+                    show: true,
+                    conjunction: 'all',
+                    conditions: [
+                      {
+                        component: 'checkbox',
+                        operator: 'isEqual',
+                        value: false,
+                      },
+                    ],
+                  },
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField3',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const submission = {
+      data: {
+        checkbox: true,
+        container: {
+          textField: 'hello',
+          textField1: 'world',
+          textField2: 'foo',
+          textField3: 'bar',
+        },
+        submit: true,
+      },
+    };
+
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.submission,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    processSync(context);
+    // Note that we DID omit textField3, which has clearOnHide enabled by default
+    assert.deepEqual(context.data, {
+      checkbox: true,
+      container: { textField: 'hello', textField1: 'world', textField2: 'foo' },
+    });
+  });
+
   it('Should not return errors for empty multiple values for url and dateTime', function () {
     const form = {
       _id: '671f7fbeaf87b0e2a26e4212',

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -84,7 +84,7 @@ export const isConditionallyHidden = (context: ConditionsContext): boolean => {
 export type ConditionallyHidden = (context: ConditionsContext) => boolean;
 
 export const conditionalProcess = (context: ConditionsContext, isHidden: ConditionallyHidden) => {
-  const { scope, path, component } = context;
+  const { scope, path, component, paths } = context;
   if (!hasConditions(context)) {
     return;
   }
@@ -94,7 +94,7 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
   }
   let conditionalComp = scope.conditionals.find((cond) => cond.path === path);
   if (!conditionalComp) {
-    const conditionalPath = path ? path : getComponentPaths(component).fullPath || '';
+    const conditionalPath = (paths ? paths.fullPath : getComponentPaths(component).fullPath) ?? '';
     conditionalComp = {
       path: conditionalPath,
       conditionallyHidden: false,

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -5,7 +5,7 @@ import {
   ProcessorInfo,
   ConditionsContext,
 } from 'types';
-import { setComponentScope } from 'utils/formUtil';
+import { getModelType, setComponentScope } from 'utils/formUtil';
 import {
   checkCustomConditional,
   checkJsonConditional,
@@ -15,7 +15,6 @@ import {
   isSimpleConditional,
   isJSONConditional,
 } from 'utils/conditions';
-import { getComponentPaths } from '../../utils/formUtil/index';
 
 const hasCustomConditions = (context: ConditionsContext): boolean => {
   const { component } = context;
@@ -94,7 +93,8 @@ export const conditionalProcess = (context: ConditionsContext, isHidden: Conditi
   }
   let conditionalComp = scope.conditionals.find((cond) => cond.path === path);
   if (!conditionalComp) {
-    const conditionalPath = (paths ? paths.fullPath : getComponentPaths(component).fullPath) ?? '';
+    // Layout components don't have data paths, so if we've conditionally hidden a layout component, use its full path
+    const conditionalPath = getModelType(component) === 'none' ? (paths?.fullPath ?? '') : path;
     conditionalComp = {
       path: conditionalPath,
       conditionallyHidden: false,

--- a/src/utils/formUtil/eachComponentDataAsync.ts
+++ b/src/utils/formUtil/eachComponentDataAsync.ts
@@ -51,6 +51,7 @@ export const eachComponentDataAsync = async (
           componentComponents,
           compPaths?.dataIndex,
           compParent,
+          compPaths,
         )) === true
       ) {
         resetComponentScope(component);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10099

## Description

If you have a layout component as a child to a container, and that layout component contains a conditional, at some point we will ask for its path, expecting something like `container.panel`. Instead, because layout components don't really have a data path (instead they have absolute paths), we will get `container`, flagging the entire container as conditionally hidden and potentially clearing the whole thing (assuming `clearOnHide` is enabled). This hotfix solution addresses this by checking the component's model type - if it is `none`, we will use the absolute path for the component when evaluating its conditional. This PR also ensures that paths are passed to the async version of `eachComponentData` under certain conditions.

I do think this reveals a weakness in our treatment of conditionals - we use the "scope" object here and there to check to see if a component somewhere else has been flagged as conditionally hidden. This is brittle, and _we already have an alternative mechanism by which to do so_: when we determine that a component is conditionally hidden, we use its ephemeral `scope` property (not to be confused with the `scope` process results object) to label it as such. A longer term solution here would be to use that property exclusively and to no longer rely on the scope for checks of this nature.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Automated test

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
