### PR TITLE
FIO-10124: fixes an issue where HTML and Content components are clearing sibling components when nested in a container

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 ## [Unreleased: 2.5.0-rc.1]
+
 ### Changed
+
 - FIO-8228: Expanding the types for Project Roles and Access Information
 - FIO-8544: Replace async callbacks with async/await
 - FIO-9942: Fix issue with disabling evaluations
@@ -15,12 +17,16 @@
 - FIO-9357 fixed calculation based on DataSource component
 
 ## 2.4.1
+
 ### Changed
+
 - FIO-9737: add deprecated tag to the unwind method
 - FIO-9908: fixed an issue where conditional setting with "show" set as a string does not work well
 
 ## 2.4.0
+
 ### Changed
+
 - FIO-9934 fixed appearing extra validation messages
 - FIO-9874: fixed an issue where operands disappear
 - Update dompurify@3.2.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/core",
-  "version": "2.4.0-dev.2",
+  "version": "2.4.0-dev.252.c19a09b",
   "description": "The core Form.io renderering framework.",
   "main": "lib/index.js",
   "exports": {

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -4861,6 +4861,326 @@ describe('Process Tests', function () {
     expect((scope as ValidationScope).errors).to.have.length(3);
   });
 
+  it('Should not clear container components when they have child layout components', function () {
+    // This form has a parent container with some layout children each containing a text field
+    // The issue was that the path was not being correctly evaluated - since the layout component contains the conditional, we were trying to get its
+    // path (something like `container.panel`) but instead received `container`, which led to the container being cleared because clearOnHide is
+    // enabled by default
+    const form = {
+      components: [
+        {
+          label: 'Checkbox',
+          tableView: false,
+          validateWhenHidden: false,
+          key: 'checkbox',
+          type: 'checkbox',
+          input: true,
+        },
+        {
+          label: 'Container',
+          tableView: false,
+          validateWhenHidden: false,
+          key: 'container',
+          type: 'container',
+          input: true,
+          components: [
+            {
+              label: 'Panel',
+              collapsible: false,
+              key: 'panel',
+              type: 'panel',
+              input: false,
+              tableView: false,
+              components: [
+                {
+                  label: 'Text Field',
+                  applyMaskOn: 'change',
+                  tableView: true,
+                  validateWhenHidden: false,
+                  key: 'textField',
+                  type: 'textfield',
+                  input: true,
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel1',
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField1',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel2',
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField2',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel3',
+                  conditional: {
+                    show: true,
+                    conjunction: 'all',
+                    conditions: [
+                      {
+                        component: 'checkbox',
+                        operator: 'isEqual',
+                        value: false,
+                      },
+                    ],
+                  },
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField3',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const submission = {
+      data: {
+        checkbox: true,
+        container: {
+          textField: 'hello',
+          textField1: 'world',
+          textField2: 'foo',
+          textField3: 'bar',
+        },
+        submit: true,
+      },
+    };
+
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.submission,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    processSync(context);
+    // Note that we DID omit textField3, which has clearOnHide enabled by default
+    assert.deepEqual(context.data, {
+      checkbox: true,
+      container: { textField: 'hello', textField1: 'world', textField2: 'foo' },
+    });
+  });
+
+  it('Should not clear container components when they have child content components', function () {
+    // This form has a parent container with some layout children each containing a text field
+    // The issue was that the path was not being correctly evaluated - since the layout component contains the conditional, we were trying to get its
+    // path (something like `container.panel`) but instead received `container`, which led to the container being cleared because clearOnHide is
+    // enabled by default
+    const form = {
+      components: [
+        {
+          label: 'Checkbox',
+          tableView: false,
+          validateWhenHidden: false,
+          key: 'checkbox',
+          type: 'checkbox',
+          input: true,
+        },
+        {
+          label: 'Container',
+          tableView: false,
+          validateWhenHidden: false,
+          key: 'container',
+          type: 'container',
+          input: true,
+          components: [
+            {
+              label: 'Panel',
+              collapsible: false,
+              key: 'panel',
+              type: 'panel',
+              input: false,
+              tableView: false,
+              components: [
+                {
+                  label: 'Text Field',
+                  applyMaskOn: 'change',
+                  tableView: true,
+                  validateWhenHidden: false,
+                  key: 'textField',
+                  type: 'textfield',
+                  input: true,
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel1',
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField1',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel2',
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField2',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+                {
+                  label: 'Panel',
+                  collapsible: false,
+                  key: 'panel3',
+                  conditional: {
+                    show: true,
+                    conjunction: 'all',
+                    conditions: [
+                      {
+                        component: 'checkbox',
+                        operator: 'isEqual',
+                        value: false,
+                      },
+                    ],
+                  },
+                  type: 'panel',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Text Field',
+                      applyMaskOn: 'change',
+                      tableView: true,
+                      validateWhenHidden: false,
+                      key: 'textField3',
+                      type: 'textfield',
+                      input: true,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              html: '<p>content, cond=true</p>',
+              label: 'Content',
+              refreshOnChange: false,
+              key: 'content',
+              conditional: {
+                show: true,
+                conjunction: 'all',
+                conditions: [
+                  {
+                    component: 'checkbox',
+                    operator: 'isEqual',
+                    value: true,
+                  },
+                ],
+              },
+              type: 'content',
+              input: false,
+              tableView: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    const submission = {
+      data: {
+        checkbox: false,
+        container: {
+          textField: 'hello',
+          textField1: 'world',
+          textField2: 'foo',
+          textField3: 'bar',
+        },
+        submit: true,
+      },
+    };
+
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.submission,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    processSync(context);
+    // Note that we DID omit textField3, which has clearOnHide enabled by default
+    assert.deepEqual(context.data, {
+      checkbox: false,
+      container: { textField: 'hello', textField1: 'world', textField2: 'foo', textField3: 'bar' },
+    });
+  });
+
   it('Should not return errors for empty multiple values for url and dateTime', function () {
     const form = {
       _id: '671f7fbeaf87b0e2a26e4212',

--- a/src/types/project/Project.ts
+++ b/src/types/project/Project.ts
@@ -4,51 +4,51 @@ import { ProjectSettings } from 'types/project/settings';
 export type ProjectId = string;
 
 export type Project = {
-    _id: ProjectId;
-    title: string;
-    name: string;
-    type?: ProjectType;
-    description?: string;
-    tag?: string;
-    owner: SubmissionId;
-    project?: string;
-    remote?: any;
-    plan: ProjectPlan;
-    billing?: ProjectBilling;
-    apiCalls?: ProjectApiCalls;
-    steps: Array<string>;
-    framework: ProjectFramework;
-    primary: boolean;
-    access: Access[];
-    trial?: Date | string;
-    lastDeploy?: Date | string;
-    stageTitle: string;
-    machineName: string;
-    config?: Record<string, string>;
-    protect: boolean;
-    settings?: ProjectSettings;
-    remoteSecret?: string;
-    builderConfig?: any;
-    formDefaults: {
-        revisions?: 'current' | 'original';
+  _id: ProjectId;
+  title: string;
+  name: string;
+  type?: ProjectType;
+  description?: string;
+  tag?: string;
+  owner: SubmissionId;
+  project?: string;
+  remote?: any;
+  plan: ProjectPlan;
+  billing?: ProjectBilling;
+  apiCalls?: ProjectApiCalls;
+  steps: Array<string>;
+  framework: ProjectFramework;
+  primary: boolean;
+  access: Access[];
+  trial?: Date | string;
+  lastDeploy?: Date | string;
+  stageTitle: string;
+  machineName: string;
+  config?: Record<string, string>;
+  protect: boolean;
+  settings?: ProjectSettings;
+  remoteSecret?: string;
+  builderConfig?: any;
+  formDefaults: {
+    revisions?: 'current' | 'original';
+  };
+  public?: {
+    custom?: {
+      css?: string;
+      js?: string;
     };
-    public?: {
-        custom?: {
-            css?: string;
-            js?: string;
-        };
-        formModule?: string;
-    };
+    formModule?: string;
+  };
 
-    // Database timestamps
-    created: Date | string;
-    modified: Date | string;
-    deleted: Date | string;
+  // Database timestamps
+  created: Date | string;
+  modified: Date | string;
+  deleted: Date | string;
 };
 
 export type ProjectRef = {
-    _id?: ProjectId;
-    name?: string;
+  _id?: ProjectId;
+  name?: string;
 };
 
 export type ProjectType = 'project' | 'stage' | 'tenant';
@@ -56,72 +56,72 @@ export type ProjectType = 'project' | 'stage' | 'tenant';
 export type ProjectPlan = 'basic' | 'independent' | 'team' | 'trial' | 'commercial';
 
 export type ProjectFramework =
-    | 'angular'
-    | 'angular2'
-    | 'react'
-    | 'vue'
-    | 'html5'
-    | 'simple'
-    | 'custom'
-    | 'aurelia'
-    | 'javascript';
+  | 'angular'
+  | 'angular2'
+  | 'react'
+  | 'vue'
+  | 'html5'
+  | 'simple'
+  | 'custom'
+  | 'aurelia'
+  | 'javascript';
 
 export type ProjectUsage = {
-    projects?: number;
-    tenants?: number;
-    stages?: number;
-    livestages?: number;
-    forms?: number;
-    emails?: number;
-    submissionRequests?: number;
-    formRequests?: number;
-    pdfs?: number;
-    pdfDownloads?: number;
-    remoteStages?: number;
-    apiServers?: number;
-    pdfServers?: number;
-    formManagers?: number;
-    vpats?: number;
-    submissionServers?: number;
-    plan?: ProjectPlan;
-    startDate?: string;
-    options?: {
-        sac?: boolean;
-        vpat?: boolean;
-        pdfBasic?: boolean;
-    };
+  projects?: number;
+  tenants?: number;
+  stages?: number;
+  livestages?: number;
+  forms?: number;
+  emails?: number;
+  submissionRequests?: number;
+  formRequests?: number;
+  pdfs?: number;
+  pdfDownloads?: number;
+  remoteStages?: number;
+  apiServers?: number;
+  pdfServers?: number;
+  formManagers?: number;
+  vpats?: number;
+  submissionServers?: number;
+  plan?: ProjectPlan;
+  startDate?: string;
+  options?: {
+    sac?: boolean;
+    vpat?: boolean;
+    pdfBasic?: boolean;
+  };
 };
 
 export type ProjectBilling = {
-    calls: number;
-    checked: number;
-    exceeds: boolean;
-    usage: ProjectUsage;
+  calls: number;
+  checked: number;
+  exceeds: boolean;
+  usage: ProjectUsage;
 };
 
 export type ProjectApiCalls = {
-    limit: ProjectUsage;
-    used: ProjectUsage;
-    reset: Date | string;
+  limit: ProjectUsage;
+  used: ProjectUsage;
+  reset: Date | string;
 };
 
 export type ProjectRole = {
-    _id: string;
-    title: string;
-    default: boolean;
-    admin: boolean;
+  _id: string;
+  title: string;
+  default: boolean;
+  admin: boolean;
 };
 
 export type FormAccessInfo = {
-    _id: string;
-    name: string;
-    path: string;
-    title: string;
-    access: Record<string, Access>;
-    submissionAccess: Record<string, Access>;
+  _id: string;
+  name: string;
+  path: string;
+  title: string;
+  access: Record<string, Access>;
+  submissionAccess: Record<string, Access>;
 };
 
 export type ProjectAccessInfo = {
-    roles: Record<string, ProjectRole>;
-    forms: Record<string, FormAccessInfo>;
+  roles: Record<string, ProjectRole>;
+  forms: Record<string, FormAccessInfo>;
 };

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -276,8 +276,7 @@ export function componentPath(
   const dataPath = type === ComponentPath.dataPath || type === ComponentPath.localDataPath;
 
   // Determine if this component should include its key.
-  const includeKey =
-    fullPath || (!!component.type && compModel !== 'none' && compModel !== 'content');
+  const includeKey = fullPath || (!!component.type && compModel !== 'none');
 
   // The key is provided if the component can have data or if we are fetching the full path.
   const key = includeKey ? getComponentKey(component) : '';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10124

## Description

When making the pathing changes, we added a conditional that essentially said "don't add the component's key to the path if it has a model type of 'none' (so, layout components) OR a model type of 'content' (so, content and HTML components)." However, I think this was an oversight - there is no reason that I can see to omit the component keys from components with a content model type, because they are still subject to things like conditionals and need to have data paths that are accessible to processors. Indeed, the cause of this bug was that when such components were nested in containers, their "path" (or data path) defaulted to their parent container, which would cause the `clearHidden` processor to clear data at the incorrect path.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Added a couple of automated tests. Additionally,

* @formio/js tests are passing ✅ 
* @formio/vm tests are passing ✅ 
* formio tests are passing ✅ 
* formio-server tests are passing ✅

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
