### PR TITLE
FIO-10052: fix old conditional formats for select boxes

### DIFF
--- a/src/process/__tests__/fixtures/conditionalWithSelectBoxes.json
+++ b/src/process/__tests__/fixtures/conditionalWithSelectBoxes.json
@@ -1,0 +1,79 @@
+{
+  "form": {
+    "title": "9.2.4 select boxes",
+    "name": "924SelectBoxes",
+    "path": "924selectboxes",
+    "type": "form",
+    "display": "form",
+    "components": [
+      {
+        "label": "Select Boxes",
+        "optionsLabelPosition": "right",
+        "tableView": false,
+        "values": [
+          {
+            "label": "dog",
+            "value": "dog",
+            "shortcut": ""
+          },
+          {
+            "label": "cat",
+            "value": "cat",
+            "shortcut": ""
+          },
+          {
+            "label": "bird",
+            "value": "bird",
+            "shortcut": ""
+          }
+        ],
+        "validateWhenHidden": false,
+        "key": "selectBoxes",
+        "type": "selectboxes",
+        "input": true,
+        "inputType": "checkbox"
+      },
+      {
+        "label": "Text Field",
+        "applyMaskOn": "change",
+        "tableView": true,
+        "validateWhenHidden": false,
+        "key": "textField",
+        "conditional": {
+          "show": true,
+          "conjunction": "all",
+          "conditions": [
+            {
+              "component": "selectBoxes.dog",
+              "operator": "isEqual",
+              "value": "true"
+            }
+          ]
+        },
+        "type": "textfield",
+        "input": true
+      },
+      {
+        "type": "button",
+        "label": "Submit",
+        "key": "submit",
+        "disableOnInvalid": true,
+        "input": true,
+        "tableView": false
+      }
+    ],
+    "created": "2025-05-12T11:49:34.499Z",
+    "modified": "2025-05-12T11:49:34.511Z"
+  },
+  "submission": {
+    "data": {
+      "selectBoxes": {
+        "dog": true,
+        "cat": false,
+        "bird": false
+      },
+      "textField": "12",
+      "submit": true
+    }
+  }
+}

--- a/src/process/__tests__/fixtures/index.ts
+++ b/src/process/__tests__/fixtures/index.ts
@@ -5,6 +5,7 @@ import skipValidForLogicallyHiddenComp from './skipValidForLogicallyHiddenComp.j
 import skipValidWithHiddenParentComp from './skipValidWithHiddenParentComp.json';
 import addressComponentWithOtherCondComponents from './addressComponentWithOtherCondComponents.json';
 import addressComponentWithOtherCondComponents2 from './addressComponentWithOtherCondComponents2.json';
+import conditionalWithSelectBoxes from './conditionalWithSelectBoxes.json';
 import forDataGridRequired from './forDataGridRequired.json';
 import data1a from './data1a.json';
 import form1 from './form1.json';
@@ -19,6 +20,7 @@ export {
   skipValidForConditionallyHiddenComp,
   skipValidWithHiddenParentComp,
   forDataGridRequired,
+  conditionalWithSelectBoxes,
   data1a,
   form1,
   subs,

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -9,6 +9,7 @@ import {
   addressComponentWithOtherCondComponents2,
   clearOnHideWithCustomCondition,
   clearOnHideWithHiddenParent,
+  conditionalWithSelectBoxes,
   forDataGridRequired,
   skipValidForConditionallyHiddenComp,
   skipValidForLogicallyHiddenComp,
@@ -3832,6 +3833,30 @@ describe('Process Tests', function () {
     context.processors = ProcessTargets.evaluator;
     processSync(context);
     assert.equal(context.scope.errors.length, 0);
+  });
+
+  it('Should set data for fields with old conditional formats for Select Boxes', async function () {
+    const errors: any = [];
+    const { form, submission } = conditionalWithSelectBoxes;
+    const context = {
+      form,
+      submission,
+      data: submission.data,
+      components: form.components,
+      processors: ProcessTargets.submission,
+      scope: { errors },
+      config: {
+        server: true,
+      },
+    };
+    processSync(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    processSync(context);
+    (context.scope as any).conditionals.forEach((v: any) =>
+      assert.equal(v.conditionallyHidden, false),
+    );
+    assert.deepEqual(context.data, submission.data);
   });
 
   it('Should not unset values for conditionally visible fields with different formats of condtion based on selectboxes value', async function () {

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -385,7 +385,7 @@ export function componentMatches(
 ) {
   let dataProperty = '';
   if (component.type === 'selectboxes') {
-    const valuePath = new RegExp(`(\\.${escapeRegExp(component.key)})(\\.[^\\.]+)$`);
+    const valuePath = new RegExp(`(\\.?${escapeRegExp(component.key)})(\\.[^\\.]+)$`);
     const pathMatches = path.match(valuePath);
     if (pathMatches?.length === 3) {
       dataProperty = pathMatches[2];


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10052

## Description
I added ".?" in regex because without it select box works only inside of other components (container, etc.).
Now it works even if select box is root component in form.

## Breaking Changes / Backwards Compatibility
n/a

## How has this PR been tested?

I added a test

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [X] Any dependent changes have corresponding PRs that are listed above
