### PR TITLE
FIO-9984: fixed an issue where default value is not set when the component does not have value in submission

### DIFF
--- a/src/process/__tests__/fixtures/componentsWithDefaultValues.json
+++ b/src/process/__tests__/fixtures/componentsWithDefaultValues.json
@@ -1,0 +1,165 @@
+{
+  "_id": "683586f0b87c1191f3b13714",
+  "title": "test def value",
+  "name": "testDefValue",
+  "path": "testdefvalue",
+  "type": "form",
+  "display": "form",
+  "owner": "637b2e6b48c1227e60b1f910",
+  "components": [
+    {
+      "label": "Text Field",
+      "applyMaskOn": "change",
+      "tableView": true,
+      "validateWhenHidden": false,
+      "key": "textField1",
+      "type": "textfield",
+      "input": true
+    },
+    {
+      "label": "Select",
+      "widget": "choicesjs",
+      "tableView": true,
+      "data": {
+        "values": [
+          {
+            "label": "one",
+            "value": "one"
+          },
+          {
+            "label": "two",
+            "value": "two"
+          }
+        ]
+      },
+      "validateWhenHidden": false,
+      "key": "select1",
+      "type": "select",
+      "input": true,
+      "defaultValue": "one"
+    },
+    {
+      "label": "Edit Grid",
+      "tableView": false,
+      "validateWhenHidden": false,
+      "rowDrafts": false,
+      "key": "editGrid1",
+      "displayAsTable": false,
+      "type": "editgrid",
+      "input": true,
+      "components": [
+        {
+          "label": "Checkbox",
+          "tableView": false,
+          "validateWhenHidden": false,
+          "key": "checkbox",
+          "type": "checkbox",
+          "input": true,
+          "defaultValue": true
+        }
+      ]
+    },
+    {
+      "label": "Text Field",
+      "applyMaskOn": "change",
+      "tableView": true,
+      "validateWhenHidden": false,
+      "key": "textField",
+      "type": "textfield",
+      "input": true,
+      "defaultValue": "test"
+    },
+    {
+      "label": "Number",
+      "applyMaskOn": "change",
+      "mask": false,
+      "tableView": false,
+      "delimiter": false,
+      "requireDecimal": false,
+      "inputFormat": "plain",
+      "truncateMultipleSpaces": false,
+      "validateWhenHidden": false,
+      "key": "number",
+      "type": "number",
+      "input": true,
+      "defaultValue": 1111
+    },
+    {
+      "label": "Text Area",
+      "applyMaskOn": "change",
+      "autoExpand": false,
+      "tableView": true,
+      "customDefaultValue": "value = 'testtt'",
+      "validateWhenHidden": false,
+      "key": "textArea",
+      "type": "textarea",
+      "input": true
+    },
+    {
+      "label": "Select",
+      "widget": "choicesjs",
+      "tableView": true,
+      "defaultValue": 2,
+      "data": {
+        "values": [
+          {
+            "label": "1",
+            "value": "1"
+          },
+          {
+            "label": "2",
+            "value": "2"
+          },
+          {
+            "label": "3",
+            "value": "3"
+          }
+        ]
+      },
+      "validateWhenHidden": false,
+      "key": "select",
+      "conditional": {
+        "show": true,
+        "when": "number",
+        "eq": "555"
+      },
+      "type": "select",
+      "input": true
+    },
+    {
+      "label": "Edit Grid",
+      "tableView": false,
+      "customDefaultValue": "value = [{textArea: 'test'},{textArea: 'test222'}]",
+      "validateWhenHidden": false,
+      "rowDrafts": false,
+      "key": "editGrid",
+      "displayAsTable": false,
+      "type": "editgrid",
+      "input": true,
+      "components": [
+        {
+          "label": "Text Area",
+          "applyMaskOn": "change",
+          "autoExpand": false,
+          "tableView": true,
+          "validateWhenHidden": false,
+          "key": "textArea",
+          "type": "textarea",
+          "input": true
+        }
+      ]
+    },
+    {
+      "type": "button",
+      "label": "Submit",
+      "key": "submit",
+      "disableOnInvalid": true,
+      "input": true,
+      "tableView": false
+    }
+  ],
+  "project": "6811ed7a80ba48135398df84",
+  "created": "2025-05-27T09:33:36.903Z",
+  "modified": "2025-05-27T13:32:30.625Z",
+  "machineName": "lszihwhpgvtoncg:testDefValue"
+}

--- a/src/process/__tests__/fixtures/index.ts
+++ b/src/process/__tests__/fixtures/index.ts
@@ -9,6 +9,7 @@ import forDataGridRequired from './forDataGridRequired.json';
 import data1a from './data1a.json';
 import form1 from './form1.json';
 import subs from './subs.json';
+import formWithDefaultValues from './componentsWithDefaultValues.json';
 
 export {
   addressComponentWithOtherCondComponents,
@@ -22,4 +23,5 @@ export {
   data1a,
   form1,
   subs,
+  formWithDefaultValues,
 };

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -13,6 +13,7 @@ import {
   skipValidForConditionallyHiddenComp,
   skipValidForLogicallyHiddenComp,
   skipValidWithHiddenParentComp,
+  formWithDefaultValues,
 } from './fixtures';
 import _ from 'lodash';
 
@@ -5487,6 +5488,80 @@ describe('Process Tests', function () {
     context.processors = ProcessTargets.evaluator;
     await process(context);
     assert.deepEqual(context.data, submission.data);
+  });
+
+  it('Should set default value for components that do not have any value in submission object', async function () {
+    const submission = {
+      data: {
+        submit: true,
+      },
+      state: 'submitted',
+    };
+
+    const context = {
+      form: formWithDefaultValues,
+      submission,
+      data: submission.data,
+      components: formWithDefaultValues.components,
+      processors: ProcessTargets.submission,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    await process(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    await process(context);
+    assert.deepEqual(context.data, {
+      submit: true,
+      select1: 'one',
+      textField: 'test',
+      textArea: 'testtt',
+      editGrid: [
+        {
+          textArea: 'test',
+        },
+        {
+          textArea: 'test222',
+        },
+      ],
+    });
+  });
+
+  it('Should not set default value for components that have empty value/own value in submission object', async function () {
+    const submission = {
+      data: {
+        textField: '',
+        textArea: 'own value',
+        editGrid: [],
+        submit: true,
+      },
+      state: 'submitted',
+    };
+
+    const context = {
+      form: formWithDefaultValues,
+      submission,
+      data: submission.data,
+      components: formWithDefaultValues.components,
+      processors: ProcessTargets.submission,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    await process(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    await process(context);
+    assert.deepEqual(context.data, {
+      textField: '',
+      textArea: 'own value',
+      editGrid: [],
+      submit: true,
+      select1: 'one',
+    });
   });
 
   describe('Required component validation in nested form in DataGrid/EditGrid', function () {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9984

## Description

**What changed?**

Previously, our filtering process ignored default values that are set by the defaultValue processors in the data object.
This PR fixes it.

## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
