### PR TITLE
FIO-10209: fix issue with incorrect error handling in developer portal app

### DIFF
--- a/src/sdk/Formio.ts
+++ b/src/sdk/Formio.ts
@@ -1618,7 +1618,7 @@ export class Formio {
               ? response.json()
               : response.text()
           ).then((error: object | string) => {
-            return Promise.reject({ ...response, error });
+            return Promise.reject(error);
           });
         }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10209

## Description

#224 introduced a breaking change that changed the shape of the error returned by the core SDK fetch subroutine. This was too aggressive because there is a lot of legacy code that consumes those errors (e.g. in the Developer Portal application, a toast is displayed). 

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
