### PR TITLE
FIO-10159: fixed an issue where value of the Custom component is not saved

### DIFF
--- a/src/utils/__tests__/formUtil.test.ts
+++ b/src/utils/__tests__/formUtil.test.ts
@@ -1777,6 +1777,39 @@ describe('formUtil', function () {
       const expected = 'any';
       expect(actual).to.equal(expected);
     });
+
+    it('Should return the correct model type for a custom component with input type', function () {
+      const component = {
+        type: 'customComponent',
+        input: true,
+        key: 'customComponent',
+        components: {
+          key: 'textFieldCustom',
+          type: 'textField',
+          input: true,
+        },
+      };
+      const actual = getModelType(component);
+      const expected = 'none';
+      expect(actual).to.equal(expected);
+    });
+
+    it('Should return the correct model type for a custom component with tree type', function () {
+      const component = {
+        type: 'customComponent',
+        input: false,
+        tree: true,
+        key: 'customComponent',
+        components: {
+          key: 'textFieldCustom',
+          type: 'textField',
+          input: true,
+        },
+      };
+      const actual = getModelType(component);
+      const expected = 'any';
+      expect(actual).to.equal(expected);
+    });
   });
 
   describe('findComponent', function () {

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -187,7 +187,11 @@ export function getModelType(component: Component): keyof typeof MODEL_TYPES_OF_
   }
 
   // Otherwise check for components that assert no value.
-  if (modelType === 'any' && component.input === false) {
+  if (
+    modelType === 'any' &&
+    (component.input === false || (component as any).components) &&
+    !(component as any).tree
+  ) {
     modelType = 'none';
   }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10159

## Description

**What changed?**

In his case the value sent to the server has only the key `textFieldCustom` in submission data object, but previously core expected it to be `customComponent.textFieldCustom`, that caused  it is missing when core was trying to get the value from data object. Added a condition to make sure that key in data object and `paths.datapath` are the same.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

tested manually, tests added

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
