### PR TITLE
FIO-10201: fixed an issue where validation is triggered for components inside conditionally hidden editGrid

### DIFF
--- a/src/process/__tests__/fixtures/index.ts
+++ b/src/process/__tests__/fixtures/index.ts
@@ -9,6 +9,7 @@ import forDataGridRequired from './forDataGridRequired.json';
 import data1a from './data1a.json';
 import form1 from './form1.json';
 import subs from './subs.json';
+import requiredFieldInsideEditGrid from './requiredFieldInsideConditionalEditGrid.json';
 
 export {
   addressComponentWithOtherCondComponents,
@@ -22,4 +23,5 @@ export {
   data1a,
   form1,
   subs,
+  requiredFieldInsideEditGrid,
 };

--- a/src/process/__tests__/fixtures/requiredFieldInsideConditionalEditGrid.json
+++ b/src/process/__tests__/fixtures/requiredFieldInsideConditionalEditGrid.json
@@ -1,0 +1,91 @@
+[{
+        "key": "selectGrids",
+        "type": "radio",
+        "input": true,
+        "label": "Select grids",
+        "inline": false,
+        "values": [{
+                "label": "Show grid 1",
+                "value": "showGrid1",
+                "shortcut": ""
+            },
+            {
+                "label": "Show grid 2",
+                "value": "showGrid2",
+                "shortcut": ""
+            }
+        ],
+        "tableView": false,
+        "validateWhenHidden": false,
+        "optionsLabelPosition": "right"
+    },
+    {
+        "key": "grid2",
+        "type": "editgrid",
+        "input": true,
+        "label": "Grid 2",
+        "rowDrafts": false,
+        "tableView": false,
+        "components": [{
+                "label": "Checkbox",
+                "tableView": false,
+                "validateWhenHidden": false,
+                "key": "checkbox",
+                "type": "checkbox",
+                "input": true
+            },
+            {
+                "label": "Text Field",
+                "applyMaskOn": "change",
+                "tableView": true,
+                "validate": {
+                    "required": true
+                },
+                "validateWhenHidden": false,
+                "key": "textField",
+                "conditional": {
+                    "show": true,
+                    "conjunction": "all",
+                    "conditions": [{
+                        "component": "grid2.checkbox",
+                        "operator": "isEqual",
+                        "value": true
+                    }]
+                },
+                "type": "textfield",
+                "input": true
+            },
+            {
+                "key": "requiredField",
+                "type": "textfield",
+                "input": true,
+                "label": "Required field",
+                "validate": {
+                    "required": true
+                },
+                "tableView": true,
+                "applyMaskOn": "change",
+                "validateWhenHidden": false
+            }
+        ],
+        "conditional": {
+            "show": true,
+            "conditions": [{
+                "value": "showGrid2",
+                "operator": "isEqual",
+                "component": "selectGrids"
+            }],
+            "conjunction": "all"
+        },
+        "displayAsTable": false,
+        "validateWhenHidden": false
+    },
+    {
+        "key": "submit",
+        "type": "button",
+        "input": true,
+        "label": "Submit",
+        "tableView": false,
+        "disableOnInvalid": true
+    }
+]

--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -13,6 +13,7 @@ import {
   skipValidForConditionallyHiddenComp,
   skipValidForLogicallyHiddenComp,
   skipValidWithHiddenParentComp,
+  requiredFieldInsideEditGrid,
 } from './fixtures';
 import _ from 'lodash';
 
@@ -6521,6 +6522,28 @@ describe('Process Tests', function () {
       context.processors = ProcessTargets.evaluator;
       processSync(context);
       assert.equal(!!context.data.textField, false);
+    });
+
+    it('Should not show validation errors for required component inside conditionally hidden editGrid', async function () {
+      const components = requiredFieldInsideEditGrid;
+      const submission = {
+        data: {
+          selectGrids: '',
+          submit: true,
+        },
+      };
+      const context = {
+        submission,
+        data: submission.data,
+        components,
+        processors: ProcessTargets.submission,
+        scope: {} as { errors: Record<string, unknown>[] },
+      };
+      processSync(context);
+      submission.data = context.data;
+      context.processors = ProcessTargets.evaluator;
+      processSync(context);
+      expect(context.scope.errors.length).to.equal(0);
     });
   });
 });

--- a/src/utils/formUtil/eachComponentData.ts
+++ b/src/utils/formUtil/eachComponentData.ts
@@ -36,6 +36,7 @@ export const eachComponentData = (
   local: boolean = false,
   parent?: Component,
   parentPaths?: ComponentPaths,
+  noScopeReset?: boolean,
 ) => {
   if (!components) {
     return;
@@ -56,7 +57,9 @@ export const eachComponentData = (
           compPaths,
         ) === true
       ) {
-        resetComponentScope(component);
+        if (!noScopeReset) {
+          resetComponentScope(component);
+        }
         return true;
       }
       if (isComponentNestedDataType(component)) {
@@ -81,6 +84,7 @@ export const eachComponentData = (
                 local,
                 component,
                 compPaths,
+                noScopeReset,
               );
             }
           } else if (includeAll || isUndefined(value)) {
@@ -92,13 +96,18 @@ export const eachComponentData = (
               local,
               component,
               compPaths,
+              noScopeReset,
             );
           }
-          resetComponentScope(component);
+          if (!noScopeReset) {
+            resetComponentScope(component);
+          }
           return true;
         } else {
           if (!includeAll && !shouldProcessComponent(component, row, value)) {
-            resetComponentScope(component);
+            if (!noScopeReset) {
+              resetComponentScope(component);
+            }
             return true;
           }
           eachComponentData(
@@ -109,15 +118,27 @@ export const eachComponentData = (
             local,
             component,
             compPaths,
+            noScopeReset,
           );
         }
-        resetComponentScope(component);
+        if (!noScopeReset) {
+          resetComponentScope(component);
+        }
         return true;
       } else if (!component.type || getModelType(component) === 'none') {
         const info = componentInfo(component);
         if (info.hasColumns) {
           (component as HasColumns).columns.forEach((column: any) =>
-            eachComponentData(column.components, data, fn, includeAll, local, component, compPaths),
+            eachComponentData(
+              column.components,
+              data,
+              fn,
+              includeAll,
+              local,
+              component,
+              compPaths,
+              noScopeReset,
+            ),
           );
         } else if (info.hasRows) {
           (component as HasRows).rows.forEach((row: any) => {
@@ -131,6 +152,7 @@ export const eachComponentData = (
                   local,
                   component,
                   compPaths,
+                  noScopeReset,
                 ),
               );
             }
@@ -144,12 +166,17 @@ export const eachComponentData = (
             local,
             component,
             compPaths,
+            noScopeReset,
           );
         }
-        resetComponentScope(component);
+        if (!noScopeReset) {
+          resetComponentScope(component);
+        }
         return true;
       }
-      resetComponentScope(component);
+      if (!noScopeReset) {
+        resetComponentScope(component);
+      }
       return false;
     },
     true,

--- a/src/utils/formUtil/eachComponentDataAsync.ts
+++ b/src/utils/formUtil/eachComponentDataAsync.ts
@@ -28,6 +28,7 @@ export const eachComponentDataAsync = async (
   local: boolean = false,
   parent?: Component,
   parentPaths?: ComponentPaths,
+  noScopeReset?: boolean,
 ) => {
   if (!components) {
     return;
@@ -53,7 +54,9 @@ export const eachComponentDataAsync = async (
           compParent,
         )) === true
       ) {
-        resetComponentScope(component);
+        if (!noScopeReset) {
+          resetComponentScope(component);
+        }
         return true;
       }
       if (isComponentNestedDataType(component)) {
@@ -75,6 +78,7 @@ export const eachComponentDataAsync = async (
                 local,
                 component,
                 compPaths,
+                noScopeReset,
               );
             }
           } else if (includeAll) {
@@ -86,13 +90,18 @@ export const eachComponentDataAsync = async (
               local,
               component,
               compPaths,
+              noScopeReset,
             );
           }
-          resetComponentScope(component);
+          if (!noScopeReset) {
+            resetComponentScope(component);
+          }
           return true;
         } else {
           if (!includeAll && !shouldProcessComponent(component, row, value)) {
-            resetComponentScope(component);
+            if (!noScopeReset) {
+              resetComponentScope(component);
+            }
             return true;
           }
           await eachComponentDataAsync(
@@ -103,9 +112,12 @@ export const eachComponentDataAsync = async (
             local,
             component,
             compPaths,
+            noScopeReset,
           );
         }
-        resetComponentScope(component);
+        if (!noScopeReset) {
+          resetComponentScope(component);
+        }
         return true;
       } else if (!component.type || getModelType(component) === 'none') {
         const info = componentInfo(component);
@@ -120,6 +132,7 @@ export const eachComponentDataAsync = async (
               local,
               component,
               compPaths,
+              noScopeReset,
             );
           }
         } else if (info.hasRows) {
@@ -135,6 +148,7 @@ export const eachComponentDataAsync = async (
                   local,
                   component,
                   compPaths,
+                  noScopeReset,
                 );
               }
             }
@@ -148,12 +162,17 @@ export const eachComponentDataAsync = async (
             local,
             component,
             compPaths,
+            noScopeReset,
           );
         }
-        resetComponentScope(component);
+        if (!noScopeReset) {
+          resetComponentScope(component);
+        }
         return true;
       }
-      resetComponentScope(component);
+      if (!noScopeReset) {
+        resetComponentScope(component);
+      }
       return false;
     },
     true,

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -507,6 +507,10 @@ export function getComponentFromPath(
         componentMatches(component, paths || {}, path, dataIndex, matches);
       },
       includeAll,
+      false,
+      undefined,
+      undefined,
+      true,
     );
   } else {
     eachComponent(
@@ -1353,7 +1357,19 @@ export function getComponentErrorField(component: Component, context: Validation
  * @returns
  */
 export function normalizeContext(context: any): any {
-  const { data, paths, local, path, form, submission, row, component, instance, value } = context;
+  const {
+    data,
+    paths,
+    local,
+    path,
+    form,
+    submission,
+    row,
+    component,
+    instance,
+    value,
+    options = {},
+  } = context;
   return {
     path: paths ? paths.localDataPath : path,
     data: paths ? getComponentLocalData(paths, data, local) : data,
@@ -1364,6 +1380,7 @@ export function normalizeContext(context: any): any {
     instance,
     value,
     input: value,
+    options,
   };
 }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10201

## Description

**What changed?**

getComponentValue inside the simple conditionals check uses the getComponentFromPath that uses the eachComponentData. The eachComponentDatathat resets the scope for each form component. The scope is needed for child components to define if parent is hidden or not. So, child components of the conditionally hidden components and the validation is triggered for them.
The getComponentValue (the same as getComponentFromPath) should not have any side affects. This PR makes the scope reset optional inside eachComponentData.

## How has this PR been tested?

manually + tests

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
