### PR TITLE
FIO-10263: rely on instance level evaluation context to provide us with submission variable

### DIFF
--- a/src/process/validation/rules/validateCustom.ts
+++ b/src/process/validation/rules/validateCustom.ts
@@ -16,7 +16,7 @@ export const shouldValidate = (context: ValidationContext) => {
 };
 
 export const validateCustomSync: RuleFnSync = (context: ValidationContext) => {
-  const { component, index, instance, value, data, row, submission } = context;
+  const { component, index, instance, value, data, row } = context;
   const customValidation = component.validate?.custom;
   try {
     if (!shouldValidate(context) || !customValidation) {
@@ -34,7 +34,6 @@ export const validateCustomSync: RuleFnSync = (context: ValidationContext) => {
       context.instance = instance;
       context.valid = true;
       context.input = value;
-      context.submission = submission;
     });
 
     if (isValid === null || isValid === true) {


### PR DESCRIPTION


## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10263

## Description

When we validate on the renderer, we [don't provide a submission value into the context](). This is a problem, because evaluation contexts need the submission variable as part of the stuff we provide the form user. However, when I made updates to the Evaluator, I accidentally added a submission "overwrite" to the evaluation context instead of just relying on what we get from the instance itself. This PR fixes the error.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Tests for this really belong in formio.js - I will add some and link them here.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
