### PR TITLE
FIO-10177: fixed an issue where only 1 validation error returns from server when datetime has array value

### DIFF
--- a/src/process/validation/__tests__/Validator.test.ts
+++ b/src/process/validation/__tests__/Validator.test.ts
@@ -38,4 +38,60 @@ describe('Validator', function () {
     }
     expect(errors).to.have.length(7);
   });
+
+  it('Validator should show 2 errors for invalid datetime value', async function () {
+    const data = {
+      dateTime: [],
+      submit: false,
+    };
+    const component = {
+      label: 'Date / Time',
+      tableView: false,
+      datePicker: {
+        disableWeekends: false,
+        disableWeekdays: false,
+      },
+      enableMinDateInput: false,
+      enableMaxDateInput: false,
+      validateWhenHidden: false,
+      key: 'dateTime',
+      type: 'datetime',
+      input: true,
+      widget: {
+        type: 'calendar',
+        displayInTimezone: 'viewer',
+        locale: 'en',
+        useLocaleSettings: false,
+        allowInput: true,
+        mode: 'single',
+        enableTime: true,
+        noCalendar: false,
+        format: 'yyyy-MM-dd hh:mm a',
+        hourIncrement: 1,
+        minuteIncrement: 1,
+        time_24hr: false,
+        minDate: null,
+        disableWeekends: false,
+        disableWeekdays: false,
+        maxDate: null,
+      },
+    };
+
+    const path = component.key;
+    const scope: ValidationScope = { errors: [] };
+    await validateProcess({
+      component,
+      scope,
+      data,
+      row: data,
+      path,
+      value: get(data, component.key),
+      processor: ProcessorType.Validate,
+      rules,
+    });
+
+    expect(scope.errors).to.have.length(2);
+    expect(scope.errors[0].errorKeyOrMessage).to.equal('invalidDate');
+    expect(scope.errors[1].errorKeyOrMessage).to.equal('nonarray');
+  });
 });

--- a/src/process/validation/rules/validateMultiple.ts
+++ b/src/process/validation/rules/validateMultiple.ts
@@ -54,6 +54,7 @@ export const emptyValueIsArray = (component: Component) => {
     case 'file':
       return true;
     case 'select':
+    case 'datetime':
     case 'textfield':
       return !!component.multiple;
     case 'tags':


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10177

## Description

**What changed?**

When the array value is submitted for datetime component, previous versions of the server returned  2 error messages ("Date / Time is not a valid date" and "Date / Time must not be an array"). The current version returns only the first message. To provide compatibility, the PR fixes it.

## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
