### PR TITLE
FIO-9984: do not set default value on server if it is falsy (the same behavior as in 8x)

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -5555,6 +5555,105 @@ describe('Process Tests', function () {
     });
   });
 
+  it('Should not set default values (when it is falsy) for components that do not have any value in submission object', async function () {
+    const submission = {
+      data: {
+        submit: true,
+      },
+      state: 'submitted',
+    };
+
+    const components = [
+      {
+        label: 'Checkbox',
+        tableView: false,
+        key: 'checkbox',
+        defaultValue: false,
+        type: 'checkbox',
+        input: true,
+      },
+      {
+        label: 'Text Field',
+        applyMaskOn: 'change',
+        tableView: true,
+        defaultValue: '',
+        key: 'textField',
+        type: 'textfield',
+        input: true,
+      },
+      {
+        label: 'Data Grid',
+        reorder: false,
+        addAnotherPosition: 'bottom',
+        layoutFixed: false,
+        enableRowGroups: false,
+        defaultValue: [],
+        initEmpty: false,
+        tableView: false,
+        key: 'dataGrid',
+        type: 'datagrid',
+        input: true,
+        components: [
+          {
+            label: 'Number',
+            applyMaskOn: 'change',
+            mask: false,
+            tableView: false,
+            delimiter: false,
+            requireDecimal: false,
+            inputFormat: 'plain',
+            truncateMultipleSpaces: false,
+            key: 'number',
+            type: 'number',
+            input: true,
+          },
+        ],
+      },
+      {
+        label: 'Number',
+        applyMaskOn: 'change',
+        mask: false,
+        tableView: false,
+        delimiter: false,
+        defaultValue: 0,
+        requireDecimal: false,
+        inputFormat: 'plain',
+        truncateMultipleSpaces: false,
+        key: 'number',
+        type: 'number',
+        input: true,
+      },
+      {
+        type: 'button',
+        label: 'Submit',
+        key: 'submit',
+        disableOnInvalid: true,
+        input: true,
+        tableView: false,
+      },
+    ];
+
+    const context = {
+      form: { components, display: 'form' },
+      submission,
+      data: submission.data,
+      components: components,
+      processors: ProcessTargets.submission,
+      scope: {},
+      config: {
+        server: true,
+      },
+    };
+    await process(context);
+    submission.data = context.data;
+    context.processors = ProcessTargets.evaluator;
+    await process(context);
+    assert.deepEqual(context.data, {
+      submit: true,
+      dataGrid: [],
+    });
+  });
+
   it('Should not set default value for components that have empty value/own value in submission object', async function () {
     const submission = {
       data: {

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -76,6 +76,10 @@ export const filterPostProcess: ProcessorFnSync<FilterScope> = (context: FilterC
   }
 
   each((scope as DefaultValueScope).defaultValues || [], ({ path, value }) => {
+    if (!value) {
+      return;
+    }
+
     if (!has(filtered, path)) {
       const component = getComponent(form?.components || [], path, true);
       // do not set default value for number and currency components as we cannot define for sure if the empty value is submitted or not


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9984

## Description

**What changed?**

To provide compatibility with 8x server, this PR does not allow to set default value on the server, when default value is falsy (0, empty string, false).

**Why have you chosen this solution?**

The same behavior as in 8x server


## Dependencies



## How has this PR been tested?

tests 

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
