### PR TITLE
FIO-9984: do not set false default values on server as it is in 8x server

### DIFF
--- a/src/process/defaultValue/index.ts
+++ b/src/process/defaultValue/index.ts
@@ -86,7 +86,9 @@ export const serverDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
     return;
   }
   let defaultValue = null;
-  if (component.defaultValue !== undefined && component.defaultValue !== null) {
+
+  // do not set false default values on server to provide compatibility with 8.x
+  if (component.defaultValue) {
     defaultValue = component.defaultValue;
     if (component.multiple && !Array.isArray(defaultValue)) {
       defaultValue = defaultValue ? [defaultValue] : [];
@@ -96,7 +98,7 @@ export const serverDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
       value: defaultValue,
     });
   }
-  if (defaultValue !== null && defaultValue !== undefined) {
+  if (defaultValue) {
     set(data, path, defaultValue);
   }
 };

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -76,10 +76,6 @@ export const filterPostProcess: ProcessorFnSync<FilterScope> = (context: FilterC
   }
 
   each((scope as DefaultValueScope).defaultValues || [], ({ path, value }) => {
-    if (!value) {
-      return;
-    }
-
     if (!has(filtered, path)) {
       const component = getComponent(form?.components || [], path, true);
       // do not set default value for number and currency components as we cannot define for sure if the empty value is submitted or not


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9984

## Description

**What changed?**

Moved logic that does not allow to set false default values from filter processor to default value processor 

## Breaking Changes / Backwards Compatibility

with  8x

## How has this PR been tested?

tests

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
