### PR TITLE
FIO-10228: Refactored the core data processors to significantly improve performance.

### DIFF
--- a/src/process/__tests__/process.test.ts
+++ b/src/process/__tests__/process.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import assert from 'node:assert';
 import type { ContainerComponent, ValidationScope } from 'types';
 import { getComponent } from 'utils/formUtil';
-import { process, processSync, ProcessTargets } from '../index';
+import { process, processSync, Processors } from '../index';
 import { fastCloneDeep } from 'utils';
 import {
   addressComponentWithOtherCondComponents,
@@ -905,7 +905,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -913,8 +913,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.equal(context.scope.errors.length, 0);
   });
 
@@ -1046,7 +1044,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -1054,8 +1052,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.equal(_.get(context.submission.data, 'form1.data.form.data.textField'), 'one 1');
     assert.equal(_.get(context.submission.data, 'form1.data.form.data.textField1'), 'two 2');
   });
@@ -1116,7 +1112,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -1203,7 +1199,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -1387,7 +1383,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -1395,8 +1391,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.equal(context.scope.errors.length, 0);
     assert.equal(context.data.showA, true);
     assert.equal(context.data.showB, true);
@@ -1583,7 +1577,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -1591,8 +1585,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.equal(context.scope.errors.length, 0);
     assert.equal(context.data.showA, false);
     assert.equal(context.data.showB, true);
@@ -1723,7 +1715,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: parentForm.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -1731,8 +1723,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.equal(context.data.showA, false);
     assert(!context.data.hasOwnProperty('childA'), 'The childA form should not be present.');
     assert.deepEqual(context.data.childB.data, {
@@ -1778,7 +1768,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -1863,7 +1853,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -1954,7 +1944,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -2044,7 +2034,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -2134,7 +2124,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -2238,7 +2228,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -2343,7 +2333,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -2447,7 +2437,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -2551,7 +2541,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -2603,7 +2593,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -2674,7 +2664,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -2768,7 +2758,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -2869,7 +2859,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -2976,7 +2966,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -3097,7 +3087,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -3226,7 +3216,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -3331,7 +3321,7 @@ describe('Process Tests', function () {
       submission: firstInvalidSubmission,
       data: firstInvalidSubmission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {} as ValidationScope,
     };
     processSync(context);
@@ -3346,7 +3336,7 @@ describe('Process Tests', function () {
       submission: secondInvalidSubmission,
       data: secondInvalidSubmission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {} as ValidationScope,
     };
     processSync(context);
@@ -3361,7 +3351,7 @@ describe('Process Tests', function () {
       submission: validSubmission,
       data: validSubmission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {} as ValidationScope,
     };
     processSync(context);
@@ -3434,7 +3424,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors: [] },
       config: { server: true },
     };
@@ -3509,7 +3499,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -3560,7 +3550,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -3609,7 +3599,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.evaluator,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -3707,7 +3697,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -3715,8 +3705,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.equal(context.scope.errors.length, 0);
     assert.deepEqual(context.data.form, { _id: '66c455fc0f00757fd4b0e79b', data: {} });
   });
@@ -3729,7 +3717,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -3737,8 +3725,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     expect(context.submission.data.number).to.be.equal(1);
     expect(context.submission.data.textField).to.be.equal('some text');
   });
@@ -3751,7 +3737,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -3759,8 +3745,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     expect(context.submission.data.number1).to.be.equal(1);
     expect(context.submission.data.number2).to.be.equal(2);
   });
@@ -3824,7 +3808,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -3832,8 +3816,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.equal(context.scope.errors.length, 0);
   });
 
@@ -3845,7 +3827,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -3853,8 +3835,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     (context.scope as any).conditionals.forEach((v: any) =>
       assert.equal(v.conditionallyHidden, false),
     );
@@ -3993,7 +3973,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors },
       config: {
         server: true,
@@ -4001,8 +3981,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     (context.scope as any).conditionals.forEach((v: any) =>
       assert.equal(v.conditionallyHidden, false),
     );
@@ -4095,7 +4073,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors, conditionals },
       config: {
         server: true,
@@ -4104,8 +4082,6 @@ describe('Process Tests', function () {
 
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     expect(context.scope.conditionals).to.have.length(1);
     expect(context.scope.conditionals?.[0].conditionallyHidden).to.equal(false);
     assert.equal(context.scope.errors.length, 0);
@@ -4245,7 +4221,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors, conditionals },
       config: {
         server: true,
@@ -4254,8 +4230,6 @@ describe('Process Tests', function () {
 
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.deepEqual(context.data, { textField: '', textAreaFieldSet: 'test' });
     context.scope.conditionals.forEach((cond: any) => {
       expect(cond.conditionallyHidden).to.be.equal(true);
@@ -4374,7 +4348,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors, conditionals },
       config: {
         server: true,
@@ -4383,8 +4357,6 @@ describe('Process Tests', function () {
 
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.deepEqual(context.data.textFieldShowOnTest1, 'test');
     context.scope.conditionals.forEach((cond: any) => {
       assert.equal(cond.conditionallyHidden, cond.path !== 'textFieldShowOnTest1');
@@ -4739,7 +4711,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors, conditionals },
       config: {
         server: true,
@@ -4748,8 +4720,6 @@ describe('Process Tests', function () {
 
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.deepEqual(context.data, data);
     context.scope.conditionals.forEach((cond: any) => {
       assert.equal(
@@ -4808,14 +4778,12 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
       },
     };
-    processSync(context);
-    context.processors = ProcessTargets.evaluator;
     const scope = processSync(context);
     expect((scope as ValidationScope).errors).to.have.length(2);
   });
@@ -4876,14 +4844,12 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
       },
     };
-    processSync(context);
-    context.processors = ProcessTargets.evaluator;
     const scope = processSync(context);
     expect((scope as ValidationScope).errors).to.have.length(3);
   });
@@ -5021,7 +4987,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -5029,8 +4995,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     // Note that we DID omit textField3, which has clearOnHide enabled by default
     assert.deepEqual(context.data, {
       checkbox: true,
@@ -5191,7 +5155,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -5199,8 +5163,6 @@ describe('Process Tests', function () {
     };
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     // Note that we DID omit textField3, which has clearOnHide enabled by default
     assert.deepEqual(context.data, {
       checkbox: false,
@@ -5285,7 +5247,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: { errors, conditionals },
       config: {
         server: true,
@@ -5294,8 +5256,6 @@ describe('Process Tests', function () {
 
     processSync(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    processSync(context);
     assert.deepEqual(context.scope.errors.length, 0);
   });
 
@@ -5495,7 +5455,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: form.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       fetch: (): Promise<Response> => {
         return Promise.resolve({
@@ -5511,8 +5471,6 @@ describe('Process Tests', function () {
     };
     await process(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    await process(context);
     assert.deepEqual(context.data, submission.data);
   });
 
@@ -5529,7 +5487,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: formWithDefaultValues.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -5537,8 +5495,6 @@ describe('Process Tests', function () {
     };
     await process(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    await process(context);
     assert.deepEqual(context.data, {
       submit: true,
       select1: 'one',
@@ -5638,7 +5594,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -5646,8 +5602,6 @@ describe('Process Tests', function () {
     };
     await process(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    await process(context);
     assert.deepEqual(context.data, {
       submit: true,
       dataGrid: [],
@@ -5670,7 +5624,7 @@ describe('Process Tests', function () {
       submission,
       data: submission.data,
       components: formWithDefaultValues.components,
-      processors: ProcessTargets.submission,
+      processors: Processors,
       scope: {},
       config: {
         server: true,
@@ -5678,8 +5632,6 @@ describe('Process Tests', function () {
     };
     await process(context);
     submission.data = context.data;
-    context.processors = ProcessTargets.evaluator;
-    await process(context);
     assert.deepEqual(context.data, {
       textField: '',
       textArea: 'own value',
@@ -5740,14 +5692,12 @@ describe('Process Tests', function () {
           submission,
           data: submission.data,
           components,
-          processors: ProcessTargets.submission,
+          processors: Processors,
           scope: {},
           config: {
             server: true,
           },
         };
-        processSync(context);
-        context.processors = ProcessTargets.evaluator;
         processSync(context);
         expect(context.data).to.deep.equal({
           dataGrid: [{ form: { data: { textField: 'test' } } }],
@@ -5813,14 +5763,12 @@ describe('Process Tests', function () {
           submission,
           data: submission.data,
           components,
-          processors: ProcessTargets.submission,
+          processors: Processors,
           scope: {},
           config: {
             server: true,
           },
         };
-        processSync(context);
-        context.processors = ProcessTargets.evaluator;
         processSync(context);
         assert.equal(context.data.radio, 'yes');
       });
@@ -5845,14 +5793,12 @@ describe('Process Tests', function () {
           submission,
           data: submission.data,
           components,
-          processors: ProcessTargets.submission,
+          processors: Processors,
           scope: {},
           config: {
             server: true,
           },
         };
-        processSync(context);
-        context.processors = ProcessTargets.evaluator;
         processSync(context);
         expect((context.scope as ValidationScope).errors).to.have.length(1);
       });
@@ -5865,15 +5811,13 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {},
         config: {
           server: true,
         },
       };
 
-      processSync(context);
-      context.processors = ProcessTargets.evaluator;
       processSync(context);
       expect((context.scope as ValidationScope).errors).to.have.length(0);
     });
@@ -5885,15 +5829,13 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {},
         config: {
           server: true,
         },
       };
 
-      await process(context);
-      context.processors = ProcessTargets.evaluator;
       await process(context);
       expect((context.scope as ValidationScope).errors).to.have.length(0);
     });
@@ -5905,15 +5847,13 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {},
         config: {
           server: true,
         },
       };
 
-      processSync(context as any);
-      context.processors = ProcessTargets.evaluator;
       processSync(context as any);
       expect((context.scope as ValidationScope).errors).to.have.length(0);
     });
@@ -5925,7 +5865,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {},
         config: {
           server: true,
@@ -5933,9 +5873,6 @@ describe('Process Tests', function () {
       };
 
       processSync(context);
-      context.processors = ProcessTargets.evaluator;
-      processSync(context);
-
       expect((context.scope as ValidationScope).errors).to.have.length(1);
     });
 
@@ -6006,7 +5943,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: { errors },
         config: {
           server: true,
@@ -6014,8 +5951,6 @@ describe('Process Tests', function () {
       };
       processSync(context);
       submission.data = context.data;
-      context.processors = ProcessTargets.evaluator;
-      processSync(context);
       assert.equal(context.scope.errors.length, 1);
       assert.equal(context.scope.errors[0].ruleName, 'required');
     });
@@ -6041,14 +5976,12 @@ describe('Process Tests', function () {
           submission,
           data: submission.data,
           components,
-          processors: ProcessTargets.submission,
+          processors: Processors,
           scope: {},
           config: {
             server: true,
           },
         };
-        processSync(context);
-        context.processors = ProcessTargets.evaluator;
         processSync(context);
         expect(context.data).to.deep.equal({ editGrid: [] });
       });
@@ -6077,14 +6010,12 @@ describe('Process Tests', function () {
           submission,
           data: submission.data,
           components,
-          processors: ProcessTargets.submission,
+          processors: Processors,
           scope: {},
           config: {
             server: true,
           },
         };
-        processSync(context);
-        context.processors = ProcessTargets.evaluator;
         processSync(context);
         console.log(JSON.stringify(context.data, null, 2));
 
@@ -6114,14 +6045,12 @@ describe('Process Tests', function () {
           submission,
           data: submission.data,
           components,
-          processors: ProcessTargets.submission,
+          processors: Processors,
           scope: {},
           config: {
             server: true,
           },
         };
-        processSync(context);
-        context.processors = ProcessTargets.evaluator;
         processSync(context);
         expect((context.scope as ValidationScope).errors).to.have.length(1);
       });
@@ -6131,12 +6060,13 @@ describe('Process Tests', function () {
   describe('clearOnHide', function () {
     it('Should not include submission data from conditionally hidden containers when clearOnHide ("Omit Data When Conditionally Hidden" is true', async function () {
       const { form, submission } = clearOnHideWithCustomCondition;
+      const clonedSubmission = JSON.parse(JSON.stringify(submission));
       const context = {
         form,
-        submission,
-        data: submission.data,
+        submission: clonedSubmission,
+        data: clonedSubmission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {},
         config: {
           server: true,
@@ -6144,9 +6074,6 @@ describe('Process Tests', function () {
       };
 
       processSync(context);
-      context.processors = ProcessTargets.evaluator;
-      processSync(context);
-
       expect(context.data).to.deep.equal({
         candidates: [{ candidate: { data: {} } }],
         submit: true,
@@ -6155,14 +6082,15 @@ describe('Process Tests', function () {
 
     it('Should not return fields from conditionally hidden containers, clearOnHide = false', async function () {
       const { form, submission } = clearOnHideWithCustomCondition;
+      const clonedSubmission = JSON.parse(JSON.stringify(submission));
       const containerComponent = getComponent(form.components, 'section6') as ContainerComponent;
       containerComponent.clearOnHide = false;
       const context = {
         form,
-        submission,
-        data: submission.data,
+        submission: clonedSubmission,
+        data: clonedSubmission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {},
         config: {
           server: true,
@@ -6170,9 +6098,6 @@ describe('Process Tests', function () {
       };
 
       processSync(context);
-      context.processors = ProcessTargets.evaluator;
-      processSync(context);
-
       expect(context.data).to.deep.equal({
         candidates: [{ candidate: { data: { section6: {} } } }],
         submit: true,
@@ -6186,7 +6111,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: { errors: [] },
         config: {
           server: true,
@@ -6194,9 +6119,6 @@ describe('Process Tests', function () {
       };
 
       processSync(context);
-      context.processors = ProcessTargets.evaluator;
-      processSync(context);
-
       expect(context.data).to.deep.equal({
         candidates: [{ candidate: { data: { section6: { c: {}, d: [] } } } }],
         submit: true,
@@ -6213,7 +6135,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components: form.components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {},
         config: {
           server: true,
@@ -6221,9 +6143,6 @@ describe('Process Tests', function () {
       };
 
       processSync(context);
-      context.processors = ProcessTargets.evaluator;
-      processSync(context);
-
       expect(context.data).to.deep.equal({
         candidates: [{ candidate: { data: { section6: { c: {}, d: [] } } } }],
         submit: true,
@@ -6252,7 +6171,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6281,7 +6200,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6320,7 +6239,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6359,7 +6278,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6398,7 +6317,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6437,7 +6356,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6485,7 +6404,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6533,7 +6452,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6582,7 +6501,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {},
       };
       processSync(context);
@@ -6624,7 +6543,7 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.evaluator,
+        processors: Processors,
         scope: {} as { errors: Record<string, unknown>[] },
       };
       processSync(context);
@@ -6713,13 +6632,11 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {} as { errors: Record<string, unknown>[] },
       };
       processSync(context);
       submission.data = context.data;
-      context.processors = ProcessTargets.evaluator;
-      processSync(context);
       assert.equal(!!context.data.textField, false);
     });
 
@@ -6735,13 +6652,11 @@ describe('Process Tests', function () {
         submission,
         data: submission.data,
         components,
-        processors: ProcessTargets.submission,
+        processors: Processors,
         scope: {} as { errors: Record<string, unknown>[] },
       };
       processSync(context);
       submission.data = context.data;
-      context.processors = ProcessTargets.evaluator;
-      processSync(context);
       expect(context.scope.errors.length).to.equal(0);
     });
   });

--- a/src/process/clearHidden/index.ts
+++ b/src/process/clearHidden/index.ts
@@ -1,14 +1,15 @@
 import { unset } from 'lodash';
 import {
-  ProcessorScope,
   ProcessorContext,
   ProcessorInfo,
   ProcessorFnSync,
   ConditionsScope,
   ProcessorFn,
+  FilterScope,
 } from 'types';
+import { getModelType, setComponentScope } from 'utils/formUtil';
 
-type ClearHiddenScope = ProcessorScope & {
+export type ClearHiddenScope = FilterScope & {
   clearHidden: {
     [path: string]: boolean;
   };
@@ -18,21 +19,32 @@ type ClearHiddenScope = ProcessorScope & {
  * This processor function checks components for the `hidden` property and unsets corresponding data
  */
 export const clearHiddenProcessSync: ProcessorFnSync<ClearHiddenScope> = (context) => {
-  const { component, data, value, scope, path } = context;
-
-  // No need to unset the value if it's undefined
-  if (value === undefined) {
-    return;
-  }
-
-  if (!scope.clearHidden) {
-    scope.clearHidden = {};
-  }
+  const { component, data, value, scope, path, parent } = context;
 
   // Check if there's a conditional set for the component and if it's marked as conditionally hidden
-  const isConditionallyHidden = (scope as ConditionsScope).conditionals?.find((cond) => {
-    return path === cond.path && cond.conditionallyHidden;
-  });
+  const isConditionallyHidden =
+    parent?.scope?.conditionallyHidden ||
+    (scope as ConditionsScope).conditionals?.find((cond) => {
+      return path === cond.path && cond.conditionallyHidden;
+    });
+
+  if (isConditionallyHidden) {
+    setComponentScope(component, 'conditionallyHidden', true);
+  }
+
+  if (
+    parent?.scope?.intentionallyHidden ||
+    (component.hasOwnProperty('hidden') && !!component.hidden)
+  ) {
+    setComponentScope(component, 'intentionallyHidden', true);
+  }
+
+  const compModel = getModelType(component);
+
+  // No need to unset the value if it's undefined or is a non-data component.
+  if (value === undefined || !component.type || compModel === 'none' || compModel === 'content') {
+    return;
+  }
 
   const shouldClearValueWhenHidden =
     !component.hasOwnProperty('clearOnHide') || component.clearOnHide;
@@ -42,7 +54,12 @@ export const clearHiddenProcessSync: ProcessorFnSync<ClearHiddenScope> = (contex
     (isConditionallyHidden || component.scope?.conditionallyHidden)
   ) {
     unset(data, path);
+    if (!scope.clearHidden) scope.clearHidden = {};
     scope.clearHidden[path] = true;
+
+    // Make sure the filter does not include the value back.
+    if (!scope.filter) scope.filter = {};
+    scope.filter[path] = false;
   }
 };
 

--- a/src/process/conditions/index.ts
+++ b/src/process/conditions/index.ts
@@ -162,5 +162,5 @@ export const conditionProcessInfo: ProcessorInfo<ConditionsContext, void> = {
   name: 'conditions',
   process: conditionProcess,
   processSync: conditionProcessSync,
-  shouldProcess: hasSimpleConditions,
+  shouldProcess: hasConditions,
 };

--- a/src/process/defaultValue/index.ts
+++ b/src/process/defaultValue/index.ts
@@ -7,7 +7,7 @@ import {
 } from 'types';
 import { set, has } from 'lodash';
 import { evaluate } from 'utils';
-import { getComponentKey } from 'utils/formUtil';
+import { getComponentKey, getModelType } from 'utils/formUtil';
 
 export const hasCustomDefaultValue = (context: DefaultValueContext): boolean => {
   const { component } = context;
@@ -35,10 +35,29 @@ export const customDefaultValueProcess: ProcessorFn<ConditionsScope> = async (
   return customDefaultValueProcessSync(context);
 };
 
+function setDefaultValue(context: DefaultValueContext, defaultValue: any) {
+  const { component, data, scope, path } = context;
+  if (defaultValue === null || defaultValue === undefined) {
+    return;
+  }
+  if (!scope.defaultValues) scope.defaultValues = [];
+  scope.defaultValues.push({
+    path,
+    value: defaultValue,
+  });
+  set(data, path, defaultValue);
+
+  // If this component is not already included in the filter and is not a number, then include it from the default.
+  if (!scope.filter) scope.filter = {};
+  if (!scope.filter[path] && getModelType(component) !== 'number') {
+    scope.filter[path] = true;
+  }
+}
+
 export const customDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
   context: DefaultValueContext,
 ) => {
-  const { component, row, data, scope, path } = context;
+  const { component, row, scope } = context;
   if (!hasCustomDefaultValue(context)) {
     return;
   }
@@ -58,14 +77,8 @@ export const customDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
     if (component.multiple && !Array.isArray(defaultValue)) {
       defaultValue = defaultValue ? [defaultValue] : [];
     }
-    scope.defaultValues.push({
-      path,
-      value: defaultValue,
-    });
   }
-  if (defaultValue !== null && defaultValue !== undefined) {
-    set(data, path, defaultValue);
-  }
+  setDefaultValue(context, defaultValue);
 };
 
 export const serverDefaultValueProcess: ProcessorFn<ConditionsScope> = async (
@@ -77,7 +90,7 @@ export const serverDefaultValueProcess: ProcessorFn<ConditionsScope> = async (
 export const serverDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
   context: DefaultValueContext,
 ) => {
-  const { component, row, data, scope, path } = context;
+  const { component, row, scope } = context;
   if (!hasServerDefaultValue(context)) {
     return;
   }
@@ -86,21 +99,13 @@ export const serverDefaultValueProcessSync: ProcessorFnSync<ConditionsScope> = (
     return;
   }
   let defaultValue = null;
-
-  // do not set false default values on server to provide compatibility with 8.x
   if (component.defaultValue) {
     defaultValue = component.defaultValue;
     if (component.multiple && !Array.isArray(defaultValue)) {
       defaultValue = defaultValue ? [defaultValue] : [];
     }
-    scope.defaultValues.push({
-      path,
-      value: defaultValue,
-    });
   }
-  if (defaultValue) {
-    set(data, path, defaultValue);
-  }
+  setDefaultValue(context, defaultValue);
 };
 
 export const defaultValueProcess: ProcessorFn<ConditionsScope> = async (

--- a/src/process/filter/__tests__/filter.test.ts
+++ b/src/process/filter/__tests__/filter.test.ts
@@ -1,8 +1,13 @@
 import { expect } from 'chai';
 
-import { filterProcessSync } from '../';
+import { filterProcessSync, filterPostProcess } from '../';
 import { generateProcessorContext } from '../../__tests__/fixtures/util';
 import { FilterScope, ProcessorContext } from 'types';
+
+const filterProcess = async (context: ProcessorContext<FilterScope>) => {
+  filterProcessSync(context);
+  filterPostProcess(context);
+};
 
 describe('Filter processor', function () {
   it('Should not filter empty array value for dataGrid component', async function () {
@@ -24,9 +29,9 @@ describe('Filter processor', function () {
       dataGrid: [],
     };
     const context: any = generateProcessorContext(dataGridComp, data);
-    filterProcessSync(context);
+    filterProcess(context);
     expect(context.scope.filter).to.deep.equal({
-      dataGrid: { compModelType: 'nestedArray', include: true, value: [] },
+      dataGrid: true,
     });
   });
 
@@ -48,9 +53,9 @@ describe('Filter processor', function () {
       editGrid: [],
     };
     const context: any = generateProcessorContext(editGridComp, data);
-    filterProcessSync(context);
+    filterProcess(context);
     expect(context.scope.filter).to.deep.equal({
-      editGrid: { compModelType: 'nestedArray', include: true, value: [] },
+      editGrid: true,
     });
   });
 
@@ -73,9 +78,9 @@ describe('Filter processor', function () {
       dataTable: [],
     };
     const context: any = generateProcessorContext(dataTableComp, data);
-    filterProcessSync(context);
+    filterProcess(context);
     expect(context.scope.filter).to.deep.equal({
-      dataTable: { compModelType: 'nestedArray', include: true, value: [] },
+      dataTable: true,
     });
   });
 
@@ -128,32 +133,28 @@ describe('Filter processor', function () {
       ],
     };
     const context: any = generateProcessorContext(tagpadComp, data);
-    filterProcessSync(context);
-    expect(context.scope.filter).to.deep.equal({
-      tagpad: {
-        compModelType: 'nestedDataArray',
-        include: true,
-        value: [
-          {
-            coordinate: {
-              x: 83,
-              y: 61,
-              width: 280,
-              height: 133,
-            },
-            data: {},
+    filterProcess(context);
+    expect(context.scope.filtered).to.deep.equal({
+      tagpad: [
+        {
+          coordinate: {
+            x: 83,
+            y: 61,
+            width: 280,
+            height: 133,
           },
-          {
-            coordinate: {
-              x: 194,
-              y: 93,
-              width: 280,
-              height: 133,
-            },
-            data: {},
+          data: {},
+        },
+        {
+          coordinate: {
+            x: 194,
+            y: 93,
+            width: 280,
+            height: 133,
           },
-        ],
-      },
+          data: {},
+        },
+      ],
     });
   });
 
@@ -184,11 +185,11 @@ describe('Filter processor', function () {
     };
 
     const context: ProcessorContext<FilterScope> = generateProcessorContext(dataMapComp, data);
-    filterProcessSync(context);
-    expect(context.scope.filter).to.deep.equal({
+    filterProcess(context);
+    expect(context.scope.filtered).to.deep.equal({
       dataMap: {
-        compModelType: 'map',
-        include: true,
+        foo: 'bar',
+        baz: 'biz',
       },
     });
   });

--- a/src/process/filter/index.ts
+++ b/src/process/filter/index.ts
@@ -1,56 +1,19 @@
 import {
-  DefaultValueScope,
   FilterContext,
   FilterScope,
   ProcessorFn,
   ProcessorFnSync,
   ProcessorInfo,
+  ProcessorPostFn,
 } from 'types';
-import { set, has, each } from 'lodash';
-import { get, isObject } from 'lodash';
-import { getComponent, getModelType } from 'utils/formUtil';
+import { has, set } from 'lodash';
+import { get } from 'lodash';
+import { getModelType } from 'utils/formUtil';
 export const filterProcessSync: ProcessorFnSync<FilterScope> = (context: FilterContext) => {
-  const { scope, component, path } = context;
-  const { value } = context;
+  const { scope, path, value } = context;
   if (!scope.filter) scope.filter = {};
   if (value !== undefined) {
-    const modelType = getModelType(component);
-    switch (modelType) {
-      case 'dataObject':
-        scope.filter[path] = {
-          compModelType: modelType,
-          include: true,
-          value: { data: {} },
-        };
-        break;
-      case 'nestedArray':
-        scope.filter[path] = {
-          compModelType: modelType,
-          include: true,
-          value: [],
-        };
-        break;
-      case 'nestedDataArray':
-        scope.filter[path] = {
-          compModelType: modelType,
-          include: true,
-          value: Array.isArray(value) ? value.map((v) => ({ ...v, data: {} })) : [],
-        };
-        break;
-      case 'object':
-        scope.filter[path] = {
-          compModelType: modelType,
-          include: true,
-          value: component.type === 'address' ? false : {},
-        };
-        break;
-      default:
-        scope.filter[path] = {
-          compModelType: modelType,
-          include: true,
-        };
-        break;
-    }
+    scope.filter[path] = true;
   }
 };
 
@@ -58,37 +21,43 @@ export const filterProcess: ProcessorFn<FilterScope> = async (context: FilterCon
   return filterProcessSync(context);
 };
 
-export const filterPostProcess: ProcessorFnSync<FilterScope> = (context: FilterContext) => {
-  const { scope, submission, form } = context;
-  const filtered = {};
-  for (const path in scope.filter) {
-    if (scope.filter[path].include) {
-      let value = get(submission?.data, path);
-      if (scope.filter[path].value) {
-        if (isObject(value) && scope.filter[path].value?.data) {
-          value = { ...value, ...scope.filter[path].value };
-        } else {
-          value = scope.filter[path].value;
-        }
-      }
-      set(filtered, path, value);
+export const filterPostProcess: ProcessorPostFn<FilterScope> = (
+  context: FilterContext,
+): boolean | undefined => {
+  const { scope, path, data, component, value } = context;
+  if (!scope.filter) scope.filter = {};
+  if (value === undefined || !scope.filter[path]) {
+    return;
+  }
+  scope.filtered = scope.filtered || {};
+  const modelType = getModelType(component);
+  if (
+    component.type === 'address' ||
+    (modelType !== 'dataObject' &&
+      modelType !== 'nestedArray' &&
+      modelType !== 'nestedDataArray' &&
+      modelType !== 'object')
+  ) {
+    set(scope.filtered, path, value);
+  } else {
+    if (modelType === 'dataObject') {
+      set(data, `${path}.data`, get(scope.filtered, `${path}.data`, value?.data || {}));
+      set(scope.filtered, path, get(data, path));
+    } else if (modelType === 'nestedDataArray') {
+      const filtered: any = get(scope.filtered, path, []);
+      set(
+        scope.filtered,
+        path,
+        value.map((item: any, index: number) => {
+          return { ...item, data: filtered[index]?.data || {} };
+        }),
+      );
+    } else if (!has(scope.filtered, path)) {
+      set(scope.filtered, path, value);
+    } else {
+      set(data, path, get(scope.filtered, path, value));
     }
   }
-
-  each((scope as DefaultValueScope).defaultValues || [], ({ path, value }) => {
-    if (!has(filtered, path)) {
-      const component = getComponent(form?.components || [], path, true);
-      // do not set default value for number and currency components as we cannot define for sure if the empty value is submitted or not
-      const noDefaultValue = component && getModelType(component) === 'number';
-      if (!noDefaultValue) {
-        const normalizedDefaultValue = has(submission?.data, path)
-          ? get(submission?.data, path)
-          : value;
-        set(filtered, path, normalizedDefaultValue);
-      }
-    }
-  });
-  context.data = filtered;
 };
 
 export const filterProcessInfo: ProcessorInfo<FilterContext, void> = {

--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -11,4 +11,3 @@ export * from './process';
 export * from './normalize';
 export * from './dereference';
 export * from './clearHidden';
-export * from './hideChildren';

--- a/src/process/processOne.ts
+++ b/src/process/processOne.ts
@@ -2,9 +2,8 @@ import { get, set } from 'lodash';
 import { ProcessorsContext, ProcessorType } from 'types';
 import { getModelType } from 'utils/formUtil';
 
-export async function processOne<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
-  const { processors, component, paths, local, path } = context;
-  // Create a getter for `value` that is always derived from the current data object
+export function contextValue<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
+  const { component, paths, local, path } = context;
   if (typeof context.value === 'undefined') {
     const dataPath = local ? paths?.localDataPath || path : paths?.dataPath || path;
     Object.defineProperty(context, 'value', {
@@ -26,7 +25,11 @@ export async function processOne<ProcessorScope>(context: ProcessorsContext<Proc
       },
     });
   }
+}
 
+export async function processOne<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
+  const { processors } = context;
+  contextValue(context);
   context.processor = ProcessorType.Custom;
   for (const processor of processors) {
     if (processor?.process) {
@@ -35,32 +38,23 @@ export async function processOne<ProcessorScope>(context: ProcessorsContext<Proc
   }
 }
 
-export function processOneSync<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
-  const { processors, component, paths, local, path } = context;
-  // Create a getter for `value` that is always derived from the current data object
-  if (typeof context.value === 'undefined') {
-    const dataPath = local ? paths?.localDataPath || path : paths?.dataPath || path;
-    Object.defineProperty(context, 'value', {
-      enumerable: true,
-      get() {
-        const modelType = getModelType(component);
-        if (!component.type || modelType === 'none' || modelType === 'content') {
-          return undefined;
-        }
-        return get(context.data, dataPath);
-      },
-      set(newValue: any) {
-        const modelType = getModelType(component);
-        if (!component.type || modelType === 'none' || modelType === 'content') {
-          // Do not set the value if the model type is 'none' or 'content'
-          return;
-        }
-        set(context.data, dataPath, newValue);
-      },
-    });
+export function postProcessOne<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
+  const { processors } = context;
+  contextValue(context);
+  context.processor = ProcessorType.Custom;
+  for (const processor of processors) {
+    if (processor?.postProcess) {
+      if (processor.postProcess(context) === true) {
+        // If this postProcess returns true, it indicates that this field does not need further post-processing.
+        break;
+      }
+    }
   }
+}
 
-  // Process the components.
+export function processOneSync<ProcessorScope>(context: ProcessorsContext<ProcessorScope>) {
+  const { processors } = context;
+  contextValue(context);
   context.processor = ProcessorType.Custom;
   for (const processor of processors) {
     if (processor?.processSync) {

--- a/src/process/validation/index.ts
+++ b/src/process/validation/index.ts
@@ -9,6 +9,7 @@ import {
   ValidationScope,
   SkipValidationFn,
   ConditionsContext,
+  ProcessorPostFn,
 } from 'types';
 import { evaluationRules, rules, serverRules } from './rules';
 import find from 'lodash/find';
@@ -376,6 +377,13 @@ export const validateAllProcessSync: ProcessorFnSync<ValidationScope> = (
   return validateProcessSync(context);
 };
 
+export const validatePostProcessSync: ProcessorPostFn<ValidationScope> = (
+  context: ValidationContext,
+): boolean | undefined => {
+  validateAllProcessSync(context);
+  return;
+};
+
 export const validateCustomProcessInfo: ProcessorInfo<ValidationContext, void> = {
   name: 'validateCustom',
   process: validateCustomProcess,
@@ -394,6 +402,12 @@ export const validateProcessInfo: ProcessorInfo<ValidationContext, void> = {
   name: 'validate',
   process: validateAllProcess,
   processSync: validateAllProcessSync,
+  shouldProcess: shouldValidateAll,
+};
+
+export const postValidateProcessInfo: ProcessorInfo<ValidationContext, void> = {
+  name: 'validate',
+  postProcess: validatePostProcessSync,
   shouldProcess: shouldValidateAll,
 };
 

--- a/src/types/formUtil.ts
+++ b/src/types/formUtil.ts
@@ -120,6 +120,12 @@ export enum ComponentPath {
    * The "localDataPath" to the TextField component from the perspective of a configuration within the Form, would be "dataGrid[1].textField"
    */
   localDataPath = 'localDataPath',
+
+  /**
+   * The contextual "row" path for the component.
+   */
+  localContextualRowPath = 'localContextualRowPath',
+  contextualRowPath = 'contextualRowPath',
 }
 
 /**
@@ -133,6 +139,8 @@ export type ComponentPaths = {
   dataPath?: string;
   localDataPath?: string;
   dataIndex?: number;
+  contextualRowPath?: string;
+  localContextualRowPath?: string;
 };
 
 export type EachComponentDataAsyncCallback = (

--- a/src/types/process/ProcessorFn.ts
+++ b/src/types/process/ProcessorFn.ts
@@ -3,3 +3,6 @@ export type ProcessorFn<ProcessorScope> = (
   context: ProcessorContext<ProcessorScope>,
 ) => Promise<void>;
 export type ProcessorFnSync<ProcessorScope> = (context: ProcessorContext<ProcessorScope>) => void;
+export type ProcessorPostFn<ProcessorScope> = (
+  context: ProcessorContext<ProcessorScope>,
+) => boolean | undefined;

--- a/src/types/process/ProcessorInfo.ts
+++ b/src/types/process/ProcessorInfo.ts
@@ -4,6 +4,6 @@ export type ProcessorInfo<ProcessorContext, ProcessorReturnType> = {
   fullValue?: boolean;
   process?: (context: ProcessorContext) => Promise<ProcessorReturnType>;
   processSync?: (context: ProcessorContext) => ProcessorReturnType;
-  postProcess?: (context: ProcessorContext) => void;
+  postProcess?: (context: ProcessorContext) => boolean | undefined;
   shouldProcess: ProcessCheckFn<ProcessorContext>;
 };

--- a/src/types/process/defaultValue/DefaultValueScope.ts
+++ b/src/types/process/defaultValue/DefaultValueScope.ts
@@ -1,8 +1,8 @@
-import { ProcessorScope } from '..';
+import { FilterScope } from '..';
 export type DefaultValueScope = {
   defaultValue?: any;
   defaultValues?: Array<{
     path: string;
     value: any;
   }>;
-} & ProcessorScope;
+} & FilterScope;

--- a/src/types/process/filter/FilterScope.ts
+++ b/src/types/process/filter/FilterScope.ts
@@ -1,11 +1,6 @@
+import { DataObject } from 'types/DataObject';
 import { ProcessorScope } from '..';
 export type FilterScope = {
-  filter: Record<
-    string,
-    {
-      compModelType: string;
-      include: boolean;
-      value?: any;
-    }
-  >;
+  filtered?: DataObject;
+  filter?: Record<string, boolean>;
 } & ProcessorScope;

--- a/src/utils/formUtil/index.ts
+++ b/src/utils/formUtil/index.ts
@@ -271,23 +271,33 @@ export function componentPath(
   const relative =
     type === ComponentPath.localPath ||
     type === ComponentPath.fullLocalPath ||
-    type === ComponentPath.localDataPath;
+    type === ComponentPath.localDataPath ||
+    type === ComponentPath.localContextualRowPath;
 
   // Full paths include all layout component ids in the path.
   const fullPath = type === ComponentPath.fullPath || type === ComponentPath.fullLocalPath;
 
   // See if this is a data path.
-  const dataPath = type === ComponentPath.dataPath || type === ComponentPath.localDataPath;
+  const dataPath =
+    type === ComponentPath.dataPath ||
+    type === ComponentPath.localDataPath ||
+    type === ComponentPath.contextualRowPath ||
+    type === ComponentPath.localContextualRowPath;
 
   // Determine if this component should include its key.
-  const includeKey = fullPath || (!!component.type && compModel !== 'none');
+  const includeKey =
+    fullPath || (!!component.type && compModel !== 'none' && compModel !== 'content');
 
   // The key is provided if the component can have data or if we are fetching the full path.
   const key = includeKey ? getComponentKey(component) : '';
 
+  // If this is a contextual row path.
+  const contextual =
+    type === ComponentPath.contextualRowPath || type === ComponentPath.localContextualRowPath;
+
   if (!parent) {
     // Return the key if there is no parent.
-    return key;
+    return contextual ? '' : key;
   }
 
   // Get the parent model type.
@@ -295,11 +305,16 @@ export function componentPath(
 
   // If there is a parent, then we only return the key if the parent is a nested form and it is a relative path.
   if (relative && parentModel === 'dataObject') {
-    return key;
+    return contextual ? '' : key;
   }
 
   // Return the parent path.
-  let parentPath = parentPaths?.hasOwnProperty(type) ? parentPaths[type] || '' : '';
+  const parentType = contextual
+    ? relative
+      ? ComponentPath.localDataPath
+      : ComponentPath.dataPath
+    : type;
+  let parentPath = parentPaths?.hasOwnProperty(parentType) ? parentPaths[parentType] || '' : '';
 
   // For data paths (where we wish to get the path to the data), we need to ensure we append the parent
   // paths to the end of the path so that any component within this component properly references their data.
@@ -310,6 +325,11 @@ export function componentPath(
     if (parentModel === 'dataObject' || parentModel === 'nestedDataArray') {
       parentPath += '.data';
     }
+  }
+
+  // If this is a contextual row path, then return here.
+  if (contextual) {
+    return parentPath;
   }
 
   // Return the parent path with its relative component path (if applicable).
@@ -336,6 +356,18 @@ export function getComponentPaths(
     dataPath: componentPath(component, parent, parentPaths, ComponentPath.dataPath),
     localDataPath: componentPath(component, parent, parentPaths, ComponentPath.localDataPath),
     dataIndex: parentPaths?.dataIndex,
+    contextualRowPath: componentPath(
+      component,
+      parent,
+      parentPaths,
+      ComponentPath.contextualRowPath,
+    ),
+    localContextualRowPath: componentPath(
+      component,
+      parent,
+      parentPaths,
+      ComponentPath.localContextualRowPath,
+    ),
   };
 }
 
@@ -549,25 +581,23 @@ export function getComponentKey(component: Component) {
   return component.key;
 }
 
-export function getContextualRowPath(
-  component: Component,
-  paths?: ComponentPaths,
-  local?: boolean,
-): string {
-  if (!paths) {
-    return '';
-  }
-  const dataPath = local ? paths.localDataPath : paths.dataPath;
-  return dataPath?.replace(new RegExp(`.?${escapeRegExp(getComponentKey(component))}$`), '') || '';
-}
-
 export function getContextualRowData(
   component: Component,
   data: any,
   paths?: ComponentPaths,
   local?: boolean,
 ): any {
-  const rowPath = getContextualRowPath(component, paths, local);
+  if (
+    paths?.hasOwnProperty('localContextualRowPath') &&
+    paths?.hasOwnProperty('contextualRowPath')
+  ) {
+    const rowPath = local ? paths?.localContextualRowPath : paths?.contextualRowPath;
+    return rowPath ? get(data, rowPath, null) : data;
+  }
+  // Fallback to the less performant regex method.
+  const dataPath = local ? paths?.localDataPath : paths?.dataPath;
+  const rowPath =
+    dataPath?.replace(new RegExp(`.?${escapeRegExp(getComponentKey(component))}$`), '') || '';
   return rowPath ? get(data, rowPath, null) : data;
 }
 
@@ -580,14 +610,20 @@ export function getComponentLocalData(paths: ComponentPaths, data: any, local?: 
   return parentPath ? get(data, parentPath, null) : data;
 }
 
-export function shouldProcessComponent(comp: Component, row: any, value: any): boolean {
+export function shouldProcessComponent(
+  comp: Component,
+  value: any,
+  paths?: ComponentPaths,
+): boolean {
   if (getModelType(comp) === 'dataObject') {
     const noReferenceAttached = value?._id ? isEmpty(value.data) && !has(value, 'form') : false;
     const shouldBeCleared =
       (!comp.hasOwnProperty('clearOnHide') || comp.clearOnHide) &&
       (comp.hidden || comp.scope?.conditionallyHidden);
+    // Also skip processing if the value is empty and the form is in an array component.
+    const emptyInDataGrid = !value && paths?.dataIndex !== undefined;
     const shouldSkipProcessingNestedFormData =
-      noReferenceAttached || (shouldBeCleared && !comp.validateWhenHidden);
+      noReferenceAttached || (shouldBeCleared && !comp.validateWhenHidden) || emptyInDataGrid;
     if (shouldSkipProcessingNestedFormData) {
       return false;
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10228

## Description

Before this change, the data processing was broken up into two separate "process" loops. The reason for this was to separate the processors that run within a VM vs. the processors that run outside of a vm. The initial thought was that this would improve performance by only executing the processors that need to be executed in a VM in a separate minified process.  An issue shows up, however, when you have a very large form (1000+ fields) since this requires that all of these fields be iterated over twice vs. one single loop.

This change mitigates that problem by reverting back to a single loop strategy for performing the processing. Also, since we only have a single loop being executed, much of the changes were to the "post" processors that create the "filtered" data objects that are sent to the server. This had to be refactored to work within the normal processing "eachComponentData" loops.

## Breaking Changes / Backwards Compatibility

None that I am aware of.

## Dependencies

None

## How has this PR been tested?

Ensure all existing tests pass.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
