### PR TITLE
FIO-10202: fixed an issue where Edit Grid with calculateOnServer: true field adds empty row on Blank Submission

### DIFF
--- a/src/process/calculation/__tests__/calculation.test.ts
+++ b/src/process/calculation/__tests__/calculation.test.ts
@@ -81,4 +81,35 @@ describe('Calculation processor', function () {
     const context: ProcessContext<CalculationScope> = await processForm(form, submission);
     expect(context.data.c).to.equal(6);
   });
+
+  it('Should not add calculated editGrid row vlaue to the blank submission ', async function () {
+    const form = {
+      components: [
+        {
+          label: 'Edit Grid',
+          key: 'editGrid',
+          type: 'editgrid',
+          input: true,
+          components: [
+            {
+              label: 'Set me on server',
+              calculateValue: 'value = "Value set on server"',
+              calculateServer: true,
+              key: 'fieldA',
+              type: 'textfield',
+              input: true,
+            },
+          ],
+        },
+      ],
+    };
+
+    const submission = {
+      data: {},
+      server: true,
+    };
+
+    const context: ProcessContext<CalculationScope> = await processForm(form, submission);
+    expect(context.data).to.deep.equal({});
+  });
 });

--- a/src/process/calculation/index.ts
+++ b/src/process/calculation/index.ts
@@ -6,12 +6,15 @@ import {
   ProcessorInfo,
   FetchScope,
 } from 'types';
-import { set } from 'lodash';
+import { set, isUndefined } from 'lodash';
 import { evaluate } from 'utils';
 
 export const shouldCalculate = (context: CalculationContext): boolean => {
-  const { component, config } = context;
+  const { component, config, value, parent } = context;
   if (!component.calculateValue || (config?.server && !component.calculateServer)) {
+    return false;
+  }
+  if (isUndefined(value) && parent?.modelType === 'nestedArray') {
     return false;
   }
   return true;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10202

## Description

After https://github.com/formio/core/pull/237 `eachComponentData` method iterates through all components that caused firing calculation process for component inside editGrid even if submission is blank. Added condition to `shouldCalculate` method to prevent unnecessary calculations. 

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

tested manually, added test
all tests pass locally

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
