### PR TITLE
FIO-10554: Fixed issue where if you do not set the variable in a calculation, that unexpected behavior occurs.

### DIFF
--- a/src/process/validation/rules/validateCustom.ts
+++ b/src/process/validation/rules/validateCustom.ts
@@ -36,7 +36,7 @@ export const validateCustomSync: RuleFnSync = (context: ValidationContext) => {
       context.input = value;
     });
 
-    if (isValid === null || isValid === true) {
+    if (isValid === null || isValid === true || isValid === undefined) {
       return null;
     }
 

--- a/src/utils/__tests__/Evaluator.test.ts
+++ b/src/utils/__tests__/Evaluator.test.ts
@@ -267,4 +267,34 @@ describe('Evaluator', function () {
       '<span>Travis</span>',
     );
   });
+
+  it('Should treat undefined variable as true in custom conditional evaluation', function () {
+    // Simulate the checkCustomConditional logic
+    const context = { data: {}, form: {}, paths: {}, local: {} };
+    // Script does not set 'show', so result should be true
+    assert.equal(
+      Evaluator.evaluate('if (false) { show = false; }', context, 'show'),
+      undefined
+    );
+    // The checkCustomConditional logic would treat undefined as true
+    // So, simulate that logic here
+    const value = Evaluator.evaluate('if (false) { show = false; }', context, 'show');
+    assert.equal(value === undefined ? true : value, true);
+
+    // Script sets show = false
+    assert.equal(
+      Evaluator.evaluate('show = false;', context, 'show'),
+      false
+    );
+    const value2 = Evaluator.evaluate('show = false;', context, 'show');
+    assert.equal(value2 === undefined ? true : value2, false);
+
+    // Script sets show = true
+    assert.equal(
+      Evaluator.evaluate('show = true;', context, 'show'),
+      true
+    );
+    const value3 = Evaluator.evaluate('show = true;', context, 'show');
+    assert.equal(value3 === undefined ? true : value3, true);
+  });
 });

--- a/src/utils/conditions.ts
+++ b/src/utils/conditions.ts
@@ -45,6 +45,12 @@ export function checkCustomConditional(
     return null;
   }
   const value = evaluate(condition, context, variable);
+  // For reverse compatability... if "show" is never set, then it should be shown. This
+  // comes from the following legacy behavior 
+  // https://github.com/formio/formio.js/blob/973b214ec6bf23d8679d0f5007b3522528abd36d/src/utils/utils.js#L311C33-L311C37
+  if (value === undefined) {
+    return true;
+  }
   if (value === null) {
     return null;
   }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10554

## Description

If you have a calculation where you do not actually set the variable, then unexpected things occur.

For example:

```
if (someCondition) {
  show = false;
}
```

This would historically show the field since it historically would be true by default, but now it hides because the "show" variable is undefined and then returns the wrong value.

## Breaking Changes / Backwards Compatibility

This resolves a breaking change between 9.x and 8.x deployments for server side behavior.

## Dependencies

None

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
